### PR TITLE
Add custom 404 message

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,15 +53,16 @@ module.exports = function download (opts, cb) {
         if (err) return cb(err)
         debug('downloading zip', url, 'to', tmpdir)
         var nuggetOpts = {target: filename, dir: tmpdir, resume: true, verbose: true, strictSSL: strictSSL, proxy: proxy}
-        nugget(url, nuggetOpts, function (err) {
-          if (/404/.test(err)) {
+        nugget(url, nuggetOpts, function (errors) {
+          if (errors) {
+            var error = errors[0]
             if (symbols) {
-              err.message = 'Failed to find Electron symbols v' + version + ' for ' + platform + '-' + arch + ' at ' + url
+              error.message = 'Failed to find Electron symbols v' + version + ' for ' + platform + '-' + arch + ' at ' + url
             } else {
-              err.message = 'Failed to find Electron v' + version + ' for ' + platform + '-' + arch + ' at ' + url
+              error.message = 'Failed to find Electron v' + version + ' for ' + platform + '-' + arch + ' at ' + url
             }
+            return cb(error)
           }
-          if (err) return cb(err)
           // when dl is done then put in cache
           debug('moving zip to', cachedZip)
           mv(path.join(tmpdir, filename), cachedZip, function (err) {

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ module.exports = function download (opts, cb) {
   var symbols = opts.symbols || false
   if (!version) return cb(new Error('must specify version'))
   var filename = 'electron-v' + version + '-' + platform + '-' + arch + (symbols ? '-symbols' : '') + '.zip'
-  var url = process.env.NPM_CONFIG_ELECTRON_MIRROR || 
-    process.env.ELECTRON_MIRROR || 
-    opts.mirror || 
+  var url = process.env.NPM_CONFIG_ELECTRON_MIRROR ||
+    process.env.ELECTRON_MIRROR ||
+    opts.mirror ||
     'https://github.com/atom/electron/releases/download/v'
   url += version + '/electron-v' + version + '-' + platform + '-' + arch + (symbols ? '-symbols' : '') + '.zip'
   var homeDir = homePath()
@@ -54,6 +54,13 @@ module.exports = function download (opts, cb) {
         debug('downloading zip', url, 'to', tmpdir)
         var nuggetOpts = {target: filename, dir: tmpdir, resume: true, verbose: true, strictSSL: strictSSL, proxy: proxy}
         nugget(url, nuggetOpts, function (err) {
+          if (/404/.test(err)) {
+            if (symbols) {
+              err = Error('Failed to find Electron symbols v' + version + ' for ' + platform + '-' + arch + ' at ' + url)
+            } else {
+              err = Error('Failed to find Electron v' + version + ' for ' + platform + '-' + arch + ' at ' + url)
+            }
+          }
           if (err) return cb(err)
           // when dl is done then put in cache
           debug('moving zip to', cachedZip)

--- a/index.js
+++ b/index.js
@@ -56,9 +56,9 @@ module.exports = function download (opts, cb) {
         nugget(url, nuggetOpts, function (err) {
           if (/404/.test(err)) {
             if (symbols) {
-              err = Error('Failed to find Electron symbols v' + version + ' for ' + platform + '-' + arch + ' at ' + url)
+              err.message = 'Failed to find Electron symbols v' + version + ' for ' + platform + '-' + arch + ' at ' + url
             } else {
-              err = Error('Failed to find Electron v' + version + ' for ' + platform + '-' + arch + ' at ' + url)
+              err.message = 'Failed to find Electron v' + version + ' for ' + platform + '-' + arch + ' at ' + url
             }
           }
           if (err) return cb(err)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "electron-download": "cli.js"
   },
   "scripts": {
-    "test": "standard && node test.js && node test_symbols.js"
+    "test": "standard && node test.js && node test_symbols.js && node test_404.js"
   },
   "repository": {
     "type": "git",

--- a/test_404.js
+++ b/test_404.js
@@ -1,0 +1,14 @@
+var download = require('./')
+
+download({
+  version: '0.25.1',
+  arch: 'ia32',
+  platform: 'darwin'
+}, function (err, zipPath) {
+  if (!err) throw Error('Download did not throw an error')
+  if (err.message !== 'Failed to find Electron v0.25.1 for darwin-ia32 at https://github.com/atom/electron/releases/download/v0.25.1/electron-v0.25.1-darwin-ia32.zip') {
+    throw Error('Download did not throw an error with a custom 404 message: ' + err.message)
+  }
+  console.log('OK! got expected error:', err.message)
+  process.exit(0)
+})


### PR DESCRIPTION
Adds a custom 404 message that front-loads the version, platform, and arch information.

This is an attempt to better showcase there is no Electron version for certain platform/arch combinations such as 32-bit Mac.

Refs https://github.com/atom/electron/issues/4655

/cc @jlord :pear: 