### PR TITLE
Allow customization of URL directory and filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ module.exports = function download (opts, cb) {
     process.env.ELECTRON_MIRROR ||
     opts.mirror ||
     'https://github.com/atom/electron/releases/download/v'
-  url += version + '/electron-v' + version + '-' + platform + '-' + arch + (symbols ? '-symbols' : '') + '.zip'
+  url += process.env.ELECTRON_CUSTOM_DIR || opts.customDir || version;
+  url += '/';
+  url += process.env.ELECTRON_CUSTOM_FILENAME || opts.customFilename || 'electron-v' + version + '-' + platform + '-' + arch + (symbols ? '-symbols' : '') + '.zip'
   var homeDir = homePath()
   var cache = opts.cache || path.join(homeDir, './.electron')
 

--- a/readme.md
+++ b/readme.md
@@ -32,9 +32,16 @@ download({
 
 if you don't specify `arch` or `platform` args it will use `require('os')` to get them from the current OS. specifying `version` is mandatory.
 
-You can set the `ELECTRON_MIRROR` or [`NPM_CONFIG_ELECTRON_MIRROR`](https://docs.npmjs.com/misc/config#environment-variables) env or `mirror` opt variable to use a custom base URL for grabbing electron zips.
+If you would like to override the mirror location, three options are available. The mirror URL is composed as `url = ELECTRON_MIRROR} + ELECTRON_CUSTOM_DIR + '/' + ELECTRON_CUSTOM_FILENAME`.
+
+You can set the `ELECTRON_MIRROR` or [`NPM_CONFIG_ELECTRON_MIRROR`](https://docs.npmjs.com/misc/config#environment-variables) env or `mirror` opt variable to use a custom base URL for grabbing electron zips. The same pattern applies to `ELECTRON_CUSTOM_DIR` and `ELECTRON_CUSTOM_FILENAME`
 
 ```plain
 ## Electron Mirror of China
 ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"
+
+## or for a local mirror
+ELECTRON_MIRROR="https://10.1.2.105/"
+ELECTRON_CUSTOM_DIR="our/internal/filePath"
 ```
+


### PR DESCRIPTION
Internally we would like to use our own mirror which does not conform to the `ELECTRON_MIRROR`/`VERSION`/`NAME`. Would you accept a PR like this?