### PR TITLE
Convert to ES6

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,13 +1,17 @@
 #!/usr/bin/env node
-var download = require('./')
-var minimist = require('minimist')
-var opts = minimist(process.argv.slice(2))
+
+'use strict'
+
+const download = require('./')
+const minimist = require('minimist')
+
+let opts = minimist(process.argv.slice(2))
 
 if (opts['strict-ssl'] === false) {
   opts.strictSSL = false
 }
 
-download(opts, function (err, zipPath) {
+download(opts, (err, zipPath) => {
   if (err) throw err
   console.log('Downloaded zip:', zipPath)
   process.exit(0)

--- a/index.js
+++ b/index.js
@@ -1,94 +1,175 @@
-var os = require('os')
-var path = require('path')
-var pathExists = require('path-exists')
-var mkdir = require('mkdirp')
-var nugget = require('nugget')
-var homePath = require('home-path')
-var mv = require('mv')
-var debug = require('debug')('electron-download')
-var npmrc = require('rc')('npm')
+'use strict'
 
-module.exports = function download (opts, cb) {
-  var platform = opts.platform || os.platform()
-  var arch = opts.arch || os.arch()
-  var version = opts.version
-  var symbols = opts.symbols || false
-  if (!version) return cb(new Error('must specify version'))
-  var filename = 'electron-v' + version + '-' + platform + '-' + arch + (symbols ? '-symbols' : '') + '.zip'
-  var url = process.env.NPM_CONFIG_ELECTRON_MIRROR ||
-    process.env.ELECTRON_MIRROR ||
-    opts.mirror ||
-    'https://github.com/electron/electron/releases/download/v'
-  url += process.env.ELECTRON_CUSTOM_DIR || opts.customDir || version
-  url += '/'
-  url += process.env.ELECTRON_CUSTOM_FILENAME || opts.customFilename || filename
-  var homeDir = homePath()
-  var cache = opts.cache || path.join(homeDir, './.electron')
+const debug = require('debug')('electron-download')
+const homePath = require('home-path')
+const mkdir = require('mkdirp')
+const mv = require('mv')
+const npmrc = require('rc')('npm')
+const nugget = require('nugget')
+const os = require('os')
+const path = require('path')
+const pathExists = require('path-exists')
 
-  var strictSSL = true
-  if (opts.strictSSL === false || npmrc['strict-ssl'] === false) {
-    strictSSL = false
+class ElectronDownloader {
+  constructor (opts) {
+    this.opts = opts
   }
 
-  var proxy
-  if (npmrc && npmrc.proxy) proxy = npmrc.proxy
-  if (npmrc && npmrc['https-proxy']) proxy = npmrc['https-proxy']
+  get baseUrl () {
+    return process.env.NPM_CONFIG_ELECTRON_MIRROR ||
+      process.env.ELECTRON_MIRROR ||
+      this.opts.mirror ||
+      'https://github.com/electron/electron/releases/download/v'
+  }
 
-  debug('info', {cache: cache, filename: filename, url: url})
+  get middleUrl () {
+    return process.env.ELECTRON_CUSTOM_DIR || this.opts.customDir || this.version
+  }
 
-  var cachedZip = path.join(cache, filename)
-  pathExists(cachedZip, function (err, exists) {
-    if (err) return cb(err)
-    if (exists) {
-      debug('zip exists', cachedZip)
-      return cb(null, cachedZip)
+  get urlSuffix () {
+    return process.env.ELECTRON_CUSTOM_FILENAME || this.opts.customFilename || this.filename
+  }
+
+  get arch () {
+    return this.opts.arch || os.arch()
+  }
+
+  get cache () {
+    return this.opts.cache || path.join(homePath(), './.electron')
+  }
+
+  get cachedZip () {
+    return path.join(this.cache, this.filename)
+  }
+
+  get filename () {
+    return `electron-v${this.version}-${this.platform}-${this.arch}${this.symbols ? '-symbols' : ''}.zip`
+  }
+
+  get platform () {
+    return this.opts.platform || os.platform()
+  }
+
+  get proxy () {
+    let proxy
+    if (npmrc && npmrc.proxy) proxy = npmrc.proxy
+    if (npmrc && npmrc['https-proxy']) proxy = npmrc['https-proxy']
+
+    return proxy
+  }
+
+  get strictSSL () {
+    let strictSSL = true
+    if (this.opts.strictSSL === false || npmrc['strict-ssl'] === false) {
+      strictSSL = false
     }
 
-    debug('creating cache/tmp dirs')
-    // otherwise download it
-    mkCacheDir(function (err, actualCache) {
-      if (err) return cb(err)
-      cachedZip = path.join(actualCache, filename) // in case cache dir changed
-      // download to tmpdir
-      var tmpdir = path.join(os.tmpdir(), 'electron-tmp-download-' + process.pid + '-' + Date.now())
-      mkdir(tmpdir, function (err) {
-        if (err) return cb(err)
-        debug('downloading zip', url, 'to', tmpdir)
-        var nuggetOpts = {target: filename, dir: tmpdir, resume: true, verbose: true, strictSSL: strictSSL, proxy: proxy}
-        nugget(url, nuggetOpts, function (errors) {
-          if (errors) {
-            var error = errors[0] // nugget returns an array of errors but we only need 1st because we only have 1 url
-            if (error.message.indexOf('404') === -1) return cb(error)
-            if (symbols) {
-              error.message = 'Failed to find Electron symbols v' + version + ' for ' + platform + '-' + arch + ' at ' + url
-            } else {
-              error.message = 'Failed to find Electron v' + version + ' for ' + platform + '-' + arch + ' at ' + url
-            }
-            return cb(error)
-          }
-          // when dl is done then put in cache
-          debug('moving zip to', cachedZip)
-          mv(path.join(tmpdir, filename), cachedZip, function (err) {
-            if (err) return cb(err)
-            cb(null, cachedZip)
-          })
-        })
-      })
-    })
-  })
+    return strictSSL
+  }
 
-  function mkCacheDir (cb) {
-    mkdir(cache, function (err) {
+  get symbols () {
+    return this.opts.symbols || false
+  }
+
+  get url () {
+    return `${this.baseUrl}${this.middleUrl}/${this.urlSuffix}`
+  }
+
+  get version () {
+    return this.opts.version
+  }
+
+  checkForCachedZip (cb) {
+    pathExists(this.cachedZip, (err, exists) => {
+      if (err) return cb(err)
+      if (exists) {
+        debug('zip exists', this.cachedZip)
+        return cb(null, this.cachedZip)
+      }
+
+      this.ensureCacheDir(cb)
+    })
+  }
+
+  createCacheDir (cb) {
+    mkdir(this.cache, (err) => {
       if (err) {
         if (err.code !== 'EACCES') return cb(err)
         // try local folder if homedir is off limits (e.g. some linuxes return '/' as homedir)
-        var localCache = path.resolve('./.electron')
+        let localCache = path.resolve('./.electron')
         return mkdir(localCache, function (err) {
           if (err) return cb(err)
           cb(null, localCache)
         })
       }
-      cb(null, cache)
+      cb(null, this.cache)
     })
   }
+
+  createTempDir (cb) {
+    this.tmpdir = path.join(os.tmpdir(), `electron-tmp-download-${process.pid}-${Date.now()}`)
+    mkdir(this.tmpdir, (err) => {
+      if (err) return cb(err)
+      this.downloadZip(cb)
+    })
+  }
+
+  downloadIfNotCached (cb) {
+    if (!this.version) return cb(new Error('must specify version'))
+    debug('info', {cache: this.cache, filename: this.filename, url: this.url})
+    this.checkForCachedZip(cb)
+  }
+
+  downloadZip (cb) {
+    debug('downloading zip', this.url, 'to', this.tmpdir)
+    let nuggetOpts = {
+      target: this.filename,
+      dir: this.tmpdir,
+      resume: true,
+      verbose: true,
+      strictSSL: this.strictSSL,
+      proxy: this.proxy
+    }
+    nugget(this.url, nuggetOpts, (errors) => {
+      if (errors) {
+        // nugget returns an array of errors but we only need 1st because we only have 1 url
+        return this.handleDownloadError(cb, errors[0])
+      }
+
+      this.moveZipToCache(cb)
+    })
+  }
+
+  ensureCacheDir (cb) {
+    debug('creating cache/tmp dirs')
+    this.createCacheDir((err, actualCache) => {
+      if (err) return cb(err)
+      this.opts.cache = actualCache // in case cache dir changed
+      this.createTempDir(cb)
+    })
+  }
+
+  handleDownloadError (cb, error) {
+    if (error.message.indexOf('404') === -1) return cb(error)
+    if (this.symbols) {
+      error.message = `Failed to find Electron symbols v${this.version} for ${this.platform}-${this.arch} at ${this.url}`
+    } else {
+      error.message = `Failed to find Electron v${this.version} for ${this.platform}-${this.arch} at ${this.url}`
+    }
+
+    return cb(error)
+  }
+
+  moveZipToCache (cb) {
+    debug('moving zip to', this.cachedZip)
+    mv(path.join(this.tmpdir, this.filename), this.cachedZip, (err) => {
+      if (err) return cb(err)
+      cb(null, this.cachedZip)
+    })
+  }
+}
+
+module.exports = function download (opts, cb) {
+  let downloader = new ElectronDownloader(opts)
+  downloader.downloadIfNotCached(cb)
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "electron-download": "cli.js"
   },
   "scripts": {
-    "test": "standard && node test.js && node test_symbols.js && node test_404.js && echo PASSED"
+    "test": "eslint . && node test.js && node test_symbols.js && node test_404.js && echo PASSED"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,21 @@
     "rc": "^1.1.2"
   },
   "devDependencies": {
-    "standard": "^3.11.1"
+    "eslint": "^3.2.0",
+    "eslint-config-standard": "^5.2.0",
+    "eslint-plugin-promise": "^2.0.0",
+    "eslint-plugin-standard": "^2.0.0"
+  },
+  "eslintConfig": {
+    "extends": "standard",
+    "parserOptions": {
+      "sourceType": "script"
+    },
+    "rules": {
+      "strict": [
+        "error"
+      ]
+    }
   },
   "keywords": []
 }

--- a/test.js
+++ b/test.js
@@ -1,10 +1,12 @@
-var download = require('./')
+'use strict'
+
+const download = require('./')
 
 download({
   version: '0.25.1',
   arch: 'ia32',
   platform: 'win32'
-}, function (err, zipPath) {
+}, (err, zipPath) => {
   if (err) throw err
   console.log('OK! zip:', zipPath)
   process.exit(0)

--- a/test_404.js
+++ b/test_404.js
@@ -1,10 +1,12 @@
-var download = require('./')
+'use strict'
+
+const download = require('./')
 
 download({
   version: '0.25.1',
   arch: 'ia32',
   platform: 'darwin'
-}, function (err, zipPath) {
+}, (err, zipPath) => {
   if (!err) throw Error('Download did not throw an error')
   if (err.message !== 'Failed to find Electron v0.25.1 for darwin-ia32 at https://github.com/electron/electron/releases/download/v0.25.1/electron-v0.25.1-darwin-ia32.zip') {
     throw Error('Download did not throw an error with a custom 404 message: ' + err.message)

--- a/test_symbols.js
+++ b/test_symbols.js
@@ -1,10 +1,12 @@
-var download = require('./')
+'use strict'
+
+const download = require('./')
 
 download({
   version: '0.26.1',
   platform: 'darwin',
   symbols: 'true'
-}, function (err, zipPath) {
+}, (err, zipPath) => {
   if (err) throw err
   console.log('OK! zip:', zipPath)
   process.exit(0)


### PR DESCRIPTION
Refactor the entirety of `index.js` to be an ES6 class. This was done mostly because it was going to take a refactor to add support for #19, anyway. In my opinion, this at least makes it more obvious as to how the module works.

This makes Node >= 4 a hard requirement, but Travis is only testing Node >=4 right now anyway.

Also, replaces `standard` with `eslint` plus the standard plugin and `'use strict'` check.