### PR TITLE
allow npmrc variable for ELECTRON_MIRROR

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ class ElectronDownloader {
 
   get baseUrl () {
     return process.env.NPM_CONFIG_ELECTRON_MIRROR ||
+      process.env.npm_config_electron_mirror ||
       process.env.ELECTRON_MIRROR ||
       this.opts.mirror ||
       'https://github.com/electron/electron/releases/download/v'

--- a/readme.md
+++ b/readme.md
@@ -47,3 +47,8 @@ ELECTRON_MIRROR="https://10.1.2.105/"
 ELECTRON_CUSTOM_DIR="our/internal/filePath"
 ```
 
+You can set these variables in `.npmrc` as well, with lower-case name
+
+```plain
+electron_mirror=https://10.1.2.105/
+```


### PR DESCRIPTION
No idea why latest npm set .npmrc variables with lower-case prefix `npm_config_` 

```
$ node -v
v6.3.1
$ npm -v
3.10.3
$ cat .npmrc
registry=https://registry.npm.taobao.org
ELECTRON_MIRROR=http://npm.taobao.org/mirrors/electron/
$ npm run env | grep MIRROR
npm_config_ELECTRON_MIRROR=http://npm.taobao.org/mirrors/electron/
```

And node-sass had changed it to [use lower-case prefix](https://github.com/sass/node-sass/blob/586a6760d2e962224b59a474a35cb781f9c24382/lib/extensions.js#L222).

So add as an fallback? Also fix #17;
