### PR TITLE
Add SHASUMS256.txt checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "electron-download": "cli.js"
   },
   "scripts": {
-    "test": "eslint . && node test.js && node test_symbols.js && node test_404.js && echo PASSED"
+    "test": "eslint . && node test.js && node test_symbols.js && node test_404.js && node test_with_checksum.js && echo PASSED"
   },
   "repository": {
     "type": "git",
@@ -21,13 +21,14 @@
   "homepage": "https://github.com/electron-userland/electron-download#readme",
   "dependencies": {
     "debug": "^2.2.0",
+    "fs-extra": "^0.30.0",
     "home-path": "^1.0.1",
     "minimist": "^1.2.0",
-    "mkdirp": "^0.5.0",
-    "mv": "^2.0.3",
     "nugget": "^2.0.0",
     "path-exists": "^3.0.0",
-    "rc": "^1.1.2"
+    "rc": "^1.1.2",
+    "semver": "^5.3.0",
+    "sumchecker": "^1.1.0"
   },
   "devDependencies": {
     "eslint": "^3.2.0",

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ download({
 })
 ```
 
-If you don't specify `arch` or `platform` args it will use the built-in `os` module to get the values from the current OS. Specifying `version` is mandatory.
+If you don't specify `arch` or `platform` args it will use the built-in `os` module to get the values from the current OS. Specifying `version` is mandatory. If there is a `SHASUMS256.txt` file available for the `version`, the file downloaded will be validated against its checksum to ensure that it was downloaded without errors.
 
 If you would like to override the mirror location, three options are available. The mirror URL is composed as `url = ELECTRON_MIRROR + ELECTRON_CUSTOM_DIR + '/' + ELECTRON_CUSTOM_FILENAME`.
 

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@
 
 const download = require('./')
 
+console.log('Basic test')
 download({
   version: '0.25.1',
   arch: 'ia32',
@@ -9,5 +10,4 @@ download({
 }, (err, zipPath) => {
   if (err) throw err
   console.log('OK! zip:', zipPath)
-  process.exit(0)
 })

--- a/test_404.js
+++ b/test_404.js
@@ -2,6 +2,7 @@
 
 const download = require('./')
 
+console.log('404 test')
 download({
   version: '0.25.1',
   arch: 'ia32',
@@ -12,5 +13,4 @@ download({
     throw Error('Download did not throw an error with a custom 404 message: ' + err.message)
   }
   console.log('OK! got expected error:', err.message)
-  process.exit(0)
 })

--- a/test_with_checksum.js
+++ b/test_with_checksum.js
@@ -2,12 +2,12 @@
 
 const download = require('./')
 
-console.log('Symbols test')
+console.log('Checksum test')
 download({
-  version: '0.26.1',
+  version: '1.3.3',
   arch: 'x64',
-  platform: 'darwin',
-  symbols: 'true'
+  platform: 'win32',
+  symbols: true
 }, (err, zipPath) => {
   if (err) throw err
   console.log('OK! zip:', zipPath)


### PR DESCRIPTION
When an Electron release has a `SHASUMS256.txt` available, it will parse that file and verify that the checksum for the given file matches what is generated by the `sumchecker` module using the contents of the file. If the file does not match, it is deleted from the Electron cache and an error is thrown.

This PR also replaces `mkdirp` and `mv` with `fs-extra`, since I had to use `fs.unlink` anyway.

CC: @kevinsawicki @zeke 

Fixes #19.