### PR TITLE
Fix broken install after ES6 conversion.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 6
+  }
+}

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-'use strict'
-
 const download = require('./')
 const minimist = require('minimist')
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
-const debug = require('debug')('electron-download')
-const fs = require('fs-extra')
-const homePath = require('home-path')
-const npmrc = require('rc')('npm')
-const nugget = require('nugget')
-const os = require('os')
-const path = require('path')
-const pathExists = require('path-exists')
-const semver = require('semver')
-const sumchecker = require('sumchecker')
+'use strict';
+var debug = require('debug')('electron-download')
+var fs = require('fs-extra')
+var homePath = require('home-path')
+var npmrc = require('rc')('npm')
+var nugget = require('nugget')
+var os = require('os')
+var path = require('path')
+var pathExists = require('path-exists')
+var semver = require('semver')
+var sumchecker = require('sumchecker')
 
 class ElectronDownloader {
   constructor (opts) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const debug = require('debug')('electron-download')
 const fs = require('fs-extra')
 const homePath = require('home-path')

--- a/test.js
+++ b/test.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const download = require('./')
 
 console.log('Basic test')

--- a/test_404.js
+++ b/test_404.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const download = require('./')
 
 console.log('404 test')

--- a/test_symbols.js
+++ b/test_symbols.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const download = require('./')
 
 console.log('Symbols test')

--- a/test_with_checksum.js
+++ b/test_with_checksum.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const download = require('./')
 
 console.log('Checksum test')


### PR DESCRIPTION
The usage of `const` outside of the module scope in `index.js` breaks the installation of this package for us, with the following error: 

```SyntaxError: Use of const in strict mode.```

So, I went ahead and fixed it! Here is what I did:

1. Create `eslintrc.json` to specify eslint to check for ES6.
2. Remove use strict inside of modules, where it is not necessary.
3. Revert `index.js` back to using `var` outside of the module scope, where `const` is not allowed.