### PR TITLE
Add quiet option to pass through to nugget

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,10 @@ class ElectronDownloader {
     return proxy
   }
 
+  get quiet () {
+    return this.opts.quiet || false
+  }
+
   get strictSSL () {
     let strictSSL = true
     if (this.opts.strictSSL === false || npmrc['strict-ssl'] === false) {
@@ -163,7 +167,7 @@ class ElectronDownloader {
       target: filename,
       dir: this.tmpdir,
       resume: true,
-      quiet: false,
+      quiet: this.quiet,
       strictSSL: this.strictSSL,
       proxy: this.proxy
     }

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,8 @@ test('Basic test', (t) => {
   download({
     version: '0.25.1',
     arch: 'ia32',
-    platform: 'win32'
+    platform: 'win32',
+    quiet: true
   }, (err, zipPath) => {
     verifyDownloadedZip(t, err, zipPath)
     t.end()

--- a/test/test_404.js
+++ b/test/test_404.js
@@ -8,7 +8,8 @@ test('404 test', (t) => {
   download({
     version: '0.25.1',
     arch: 'ia32',
-    platform: 'darwin'
+    platform: 'darwin',
+    quiet: true
   }, (err, zipPath) => {
     if (!err) t.fail('Download should throw an error')
     t.equal(fs.existsSync(zipPath), false, 'Zip path should not exist')

--- a/test/test_symbols.js
+++ b/test/test_symbols.js
@@ -9,7 +9,8 @@ test('Symbols test', (t) => {
     version: '0.26.1',
     arch: 'x64',
     platform: 'darwin',
-    symbols: true
+    symbols: true,
+    quiet: true
   }, (err, zipPath) => {
     verifyDownloadedZip(t, err, zipPath)
     t.ok(/-symbols\.zip$/.test(zipPath), 'Zip path should end with -symbols.zip')

--- a/test/test_with_checksum.js
+++ b/test/test_with_checksum.js
@@ -9,7 +9,8 @@ test('Checksum test', (t) => {
     version: '1.3.3',
     arch: 'x64',
     platform: 'win32',
-    symbols: true
+    symbols: true,
+    quiet: true
   }, (err, zipPath) => {
     verifyDownloadedZip(t, err, zipPath)
     t.end()


### PR DESCRIPTION
Allow `quiet` to be a configurable option that gets passed through to `nugget`.

Still defaults to `false` but can be overridden, such as by the specs, for less-noisy CI output.