### PR TITLE
Enable quiet mode when no room to show progress bar

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,7 @@ class ElectronDownloader {
   }
 
   get quiet () {
-    return this.opts.quiet || false
+    return this.opts.quiet || process.stdout.rows === 0
   }
 
   get strictSSL () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,7 @@ class ElectronDownloader {
   }
 
   get quiet () {
-    return this.opts.quiet || process.stdout.rows === 0
+    return this.opts.quiet || process.stdout.rows < 1
   }
 
   get strictSSL () {


### PR DESCRIPTION
Until the root cause of https://github.com/electron-userland/electron-prebuilt/issues/193 is tracked down just disable the progress bar when there `stdout.rows` is `0` meaning the progress bar isn't showable.

This seems to be the case on Mac Travis CI workers.

Closes #34 