### PR TITLE
download file to __dirname instead of os.tmpdir()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -150,7 +150,7 @@ class ElectronDownloader {
   }
 
   createTempDir (cb, onSuccess) {
-    this.tmpdir = path.join(os.tmpdir(), `electron-tmp-download-${process.pid}-${Date.now()}`)
+    this.tmpdir = path.join(__dirname, `electron-tmp-download-${process.pid}-${Date.now()}`)
     fs.mkdirs(this.tmpdir, (err) => {
       if (err) return cb(err)
       onSuccess(cb)


### PR DESCRIPTION
Possibly fixes https://github.com/electron-userland/electron-prebuilt/issues/139

cc @mafintosh. Is this what you were suggesting?
