### PR TITLE
Save cache to standard directory

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const debug = require('debug')('electron-download')
+const envPaths = require('env-paths')
 const fs = require('fs-extra')
 const homePath = require('home-path')
 const rc = require('rc')
@@ -44,7 +45,8 @@ class ElectronDownloader {
   }
 
   get cache () {
-    return this.opts.cache || path.join(homePath(), './.electron')
+    // use passed argument or XDG environment variable fallback to OS default
+    return this.opts.cache || envPaths('electron-download', {suffix: ''}).cache
   }
 
   get cachedChecksum () {
@@ -171,18 +173,25 @@ class ElectronDownloader {
   }
 
   createCacheDir (cb) {
-    fs.mkdirs(this.cache, (err) => {
-      if (err) {
-        if (err.code !== 'EACCES') return cb(err)
-        // try local folder if homedir is off limits (e.g. some linuxes return '/' as homedir)
-        let localCache = path.resolve('./.electron')
-        return fs.mkdirs(localCache, function (err) {
-          if (err) return cb(err)
-          cb(null, localCache)
-        })
-      }
-      cb(null, this.cache)
-    })
+    try {
+      // if files exist in the old path use and migrate it
+      const oldPath = path.join(homePath(), './.electron')
+      fs.renameSync(oldPath, envPaths('electron-download', {suffix: ''}).cache)
+    } catch (e) {
+      fs.mkdirs(this.cache, (err) => {
+        if (err) {
+          if (err.code !== 'EACCES') return cb(err)
+
+          // try local folder if homedir is off limits (e.g. some linuxes return '/' as homedir)
+          let localCache = path.resolve('./.electron')
+          return fs.mkdirs(localCache, function (err) {
+            if (err) return cb(err)
+            cb(null, localCache)
+          })
+        }
+      })
+    }
+    cb(null, this.cache)
   }
 
   createTempDir (cb, onSuccess) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ class ElectronDownloader {
 
   get cache () {
     // use passed argument or XDG environment variable fallback to OS default
-    return this.opts.cache || envPaths('electron-download', {suffix: ''}).cache
+    return this.opts.cache || envPaths('electron', {suffix: ''}).cache
   }
 
   get cachedChecksum () {
@@ -176,7 +176,7 @@ class ElectronDownloader {
     try {
       // if files exist in the old path use and migrate it
       const oldPath = path.join(homePath(), './.electron')
-      fs.renameSync(oldPath, envPaths('electron-download', {suffix: ''}).cache)
+      fs.renameSync(oldPath, envPaths('electron', {suffix: ''}).cache)
     } catch (e) {
       fs.mkdirs(this.cache, (err) => {
         if (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,6 +53,11 @@ class ElectronDownloader {
   }
 
   get cachedZip () {
+    const oldLocation = path.join(os.homedir(), './.electron', this.filename)
+    if (pathExists.sync(oldLocation)) {
+      return oldLocation
+    }
+
     return path.join(this.cache, this.filename)
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -178,25 +178,18 @@ class ElectronDownloader {
   }
 
   createCacheDir (cb) {
-    try {
-      // if files exist in the old path use and migrate it
-      const oldPath = path.join(homePath(), './.electron')
-      fs.renameSync(oldPath, envPaths('electron', {suffix: ''}).cache)
-    } catch (e) {
-      fs.mkdirs(this.cache, (err) => {
-        if (err) {
-          if (err.code !== 'EACCES') return cb(err)
-
-          // try local folder if homedir is off limits (e.g. some linuxes return '/' as homedir)
-          let localCache = path.resolve('./.electron')
-          return fs.mkdirs(localCache, function (err) {
-            if (err) return cb(err)
-            cb(null, localCache)
-          })
-        }
-      })
-    }
-    cb(null, this.cache)
+    fs.mkdirs(this.cache, (err) => {
+      if (err) {
+        if (err.code !== 'EACCES') return cb(err)
+        // try local folder if homedir is off limits (e.g. some linuxes return '/' as homedir)
+        let localCache = path.resolve('./.electron')
+        return fs.mkdirs(localCache, function (err) {
+          if (err) return cb(err)
+          cb(null, localCache)
+        })
+      }
+      cb(null, this.cache)
+    })
   }
 
   createTempDir (cb, onSuccess) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "debug": "^2.2.0",
     "env-paths": "^0.3.0",
     "fs-extra": "^2.0.0",
-    "home-path": "^1.0.1",
     "minimist": "^1.2.0",
     "nugget": "^2.0.0",
     "path-exists": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/electron-userland/electron-download#readme",
   "dependencies": {
     "debug": "^2.2.0",
+    "env-paths": "^0.3.0",
     "fs-extra": "^0.30.0",
     "home-path": "^1.0.1",
     "minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/electron-userland/electron-download#readme",
   "dependencies": {
     "debug": "^2.2.0",
-    "env-paths": "^0.3.0",
+    "env-paths": "^1.0.0",
     "fs-extra": "^2.0.0",
     "minimist": "^1.2.0",
     "nugget": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -63,3 +63,10 @@ You can set ELECTRON_MIRROR in `.npmrc` as well, using the lowercase name:
 ```plain
 electron_mirror=https://10.1.2.105/
 ```
+
+### Cache location
+The location of the cache depends on the operating system, the defaults are:
+- Linux: `$XDG_CACHE_HOME` or `~/.cache/electron/`
+- MacOS: `~/Library/Caches/electron/`
+- Windows: `$LOCALAPPDATA/electron/Cache` or `~/AppData/Local/electron/Cache/`
+

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ download({
   version: '0.25.1',
   arch: 'ia32',
   platform: 'win32',
-  cache: './zips' // defaults to <user's home directory>/.electron
+  cache: './zips' // defaults to <user's cache directory>/electron-download
 }, function (err, zipPath) {
   // zipPath will be the path of the zip that it downloaded.
   // If the zip was already cached it will skip

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ download({
   version: '0.25.1',
   arch: 'ia32',
   platform: 'win32',
-  cache: './zips' // defaults to <user's cache directory>/electron-download
+  cache: './zips'
 }, function (err, zipPath) {
   // zipPath will be the path of the zip that it downloaded.
   // If the zip was already cached it will skip

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const download = require('../lib/index')
+const envPaths = require('env-paths')
 const fs = require('fs')
+const homePath = require('home-path')
 const path = require('path')
 const temp = require('temp').track()
 const test = require('tape')
@@ -19,6 +21,7 @@ test('Basic test', (t) => {
   })
 })
 
+<<<<<<< 6cd027ea33232966abc4efcaf1215133df966572
 test('Force option', (t) => {
   const cachePath = temp.mkdirSync('electron-download-')
 
@@ -40,25 +43,29 @@ test('Force option', (t) => {
 })
 
 test('Cache directory is moved to new location', (t) => {
-  // Download to old cache directory location
-  download({
-    version: '1.4.3',
-    arch: 'x64',
-    platform: 'linux',
-    cache: path.join(homePath(), './.electron')
-  }, (err, oldZipPath) => {
-    verifyDownloadedZip(t, err, oldZipPath)
+  const oldCachePath = path.join(homePath(), './.electron')
+  const newCachePath = envPaths('electron-download', {suffix: ''}).cache
+
+  fs.mkdir(oldCachePath, () => {
+    // Put file in old cache location
+    fs.writeFileSync(path.join(oldCachePath, 'moveMe'))
+
     download({
-      version: '1.4.4',
+      version: '1.1.0',
       arch: 'x64',
       platform: 'linux'
-    }, (err, zipPath) => {
-      const oldZipPathName = path.parse(oldZipPath).base
-      const movedOldZipPath = path.parse(zipPath)
-      movedOldZipPath.base = oldZipPathName
+    }, (downloadError, zipPath) => {
+      t.false(downloadError)
 
-      verifyDownloadedZip(t, err, path.format(movedOldZipPath))
-      t.end()
+      fs.stat(path.join(newCachePath, 'moveMe'), (error) => {
+        // If file exists no error is returned
+        t.false(error, 'File should be moved to new cache directory')
+
+        // Cleanup
+        fs.unlinkSync(path.join(newCachePath, 'moveMe'))
+
+        t.end()
+      })
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -38,3 +38,27 @@ test('Force option', (t) => {
     t.end()
   })
 })
+
+test('Cache directory is moved to new location', (t) => {
+  // Download to old cache directory location
+  download({
+    version: '1.4.3',
+    arch: 'x64',
+    platform: 'linux',
+    cache: path.join(homePath(), './.electron')
+  }, (err, oldZipPath) => {
+    verifyDownloadedZip(t, err, oldZipPath)
+    download({
+      version: '1.4.4',
+      arch: 'x64',
+      platform: 'linux'
+    }, (err, zipPath) => {
+      const oldZipPathName = path.parse(oldZipPath).base
+      const movedOldZipPath = path.parse(zipPath)
+      movedOldZipPath.base = oldZipPathName
+
+      verifyDownloadedZip(t, err, path.format(movedOldZipPath))
+      t.end()
+    })
+  })
+})

--- a/test/test.js
+++ b/test/test.js
@@ -21,7 +21,6 @@ test('Basic test', (t) => {
   })
 })
 
-<<<<<<< 6cd027ea33232966abc4efcaf1215133df966572
 test('Force option', (t) => {
   const cachePath = temp.mkdirSync('electron-download-')
 

--- a/test/test.js
+++ b/test/test.js
@@ -44,7 +44,7 @@ test('Force option', (t) => {
 
 test('Cache directory is moved to new location', (t) => {
   const oldCachePath = path.join(homePath(), './.electron')
-  const newCachePath = envPaths('electron-download', {suffix: ''}).cache
+  const newCachePath = envPaths('electron', {suffix: ''}).cache
 
   fs.mkdir(oldCachePath, () => {
     // Put file in old cache location

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,7 @@
 'use strict'
 
 const download = require('../lib/index')
-const envPaths = require('env-paths')
 const fs = require('fs')
-const homePath = require('home-path')
 const path = require('path')
 const temp = require('temp').track()
 const test = require('tape')
@@ -38,33 +36,5 @@ test('Force option', (t) => {
   }, (err, zipPath) => {
     verifyDownloadedZip(t, err, zipPath)
     t.end()
-  })
-})
-
-test('Cache directory is moved to new location', (t) => {
-  const oldCachePath = path.join(homePath(), './.electron')
-  const newCachePath = envPaths('electron', {suffix: ''}).cache
-
-  fs.mkdir(oldCachePath, () => {
-    // Put file in old cache location
-    fs.writeFileSync(path.join(oldCachePath, 'moveMe'))
-
-    download({
-      version: '1.1.0',
-      arch: 'x64',
-      platform: 'linux'
-    }, (downloadError, zipPath) => {
-      t.false(downloadError)
-
-      fs.stat(path.join(newCachePath, 'moveMe'), (error) => {
-        // If file exists no error is returned
-        t.false(error, 'File should be moved to new cache directory')
-
-        // Cleanup
-        fs.unlinkSync(path.join(newCachePath, 'moveMe'))
-
-        t.end()
-      })
-    })
   })
 })


### PR DESCRIPTION
The cache is saved to a standard cache directory using the "env-paths"
module, rather than saving in the home directory.
The old cache directory will automatically be migrated to the new
location.

BREAKING CHANGE: Cache is no longer stored in `~/.electron`.
