### PR TITLE
bump dependencies, require node 4, remove home-path dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,10 @@ os:
 osx_image: xcode7.3
 language: node_js
 node_js:
-- '0.10'
-- '0.12'
 - '4'
 - '5'
 - '6'
+- '7'
 cache:
 - directories:
   - "$HOME/.npm"

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@
 
 const debug = require('debug')('electron-download')
 const fs = require('fs-extra')
-const homePath = require('home-path')
 const rc = require('rc')
 const nugget = require('nugget')
 const os = require('os')
@@ -44,7 +43,7 @@ class ElectronDownloader {
   }
 
   get cache () {
-    return this.opts.cache || path.join(homePath(), './.electron')
+    return this.opts.cache || path.join(os.homedir(), './.electron')
   }
 
   get cachedChecksum () {

--- a/package.json
+++ b/package.json
@@ -23,13 +23,12 @@
   },
   "homepage": "https://github.com/electron-userland/electron-download#readme",
   "dependencies": {
-    "debug": "^2.2.0",
-    "fs-extra": "^0.30.0",
-    "home-path": "^1.0.1",
+    "debug": "^2.3.2",
+    "fs-extra": "^1.0.0",
     "minimist": "^1.2.0",
-    "nugget": "^2.0.0",
-    "path-exists": "^2.1.0",
-    "rc": "^1.1.2",
+    "nugget": "^2.0.1",
+    "path-exists": "^3.0.0",
+    "rc": "^1.1.6",
     "semver": "^5.3.0",
     "sumchecker": "^1.2.0"
   },
@@ -58,8 +57,11 @@
   },
   "babel": {
     "presets": [
-      "es2015"
+      "es2015-node4"
     ]
   },
-  "keywords": []
+  "keywords": [],
+  "engines": {
+     "node": ">= 4.0"
+   }
 }

--- a/package.json
+++ b/package.json
@@ -23,25 +23,25 @@
   },
   "homepage": "https://github.com/electron-userland/electron-download#readme",
   "dependencies": {
-    "debug": "^2.3.2",
-    "fs-extra": "^1.0.0",
+    "debug": "^2.6.0",
+    "fs-extra": "^2.0.0",
     "minimist": "^1.2.0",
     "nugget": "^2.0.1",
     "path-exists": "^3.0.0",
     "rc": "^1.1.6",
     "semver": "^5.3.0",
-    "sumchecker": "^1.2.0"
+    "sumchecker": "^2.0.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.14.0",
-    "babel-preset-es2015": "^6.14.0",
-    "babel-register": "^6.14.0",
-    "eslint": "^3.2.0",
-    "eslint-config-standard": "^5.2.0",
-    "eslint-plugin-promise": "^2.0.0",
-    "eslint-plugin-standard": "^2.0.0",
+    "babel-cli": "^6.22.2",
+    "babel-preset-es2015-node4": "^2.1.1",
+    "babel-register": "^6.22.0",
+    "eslint": "^3.14.1",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-promise": "^3.4.0",
+    "eslint-plugin-standard": "^2.0.1",
     "mkdirp": "^0.5.1",
-    "tape": "^4.6.0",
+    "tape": "^4.6.3",
     "temp": "^0.8.3"
   },
   "eslintConfig": {

--- a/test/test_bad_config.js
+++ b/test/test_bad_config.js
@@ -2,14 +2,14 @@
 
 const download = require('../lib/index')
 const fs = require('fs')
-const homePath = require('home-path')
+const os = require('os')
 const mkdirp = require('mkdirp').sync
 const path = require('path')
 const test = require('tape')
 const verifyDownloadedZip = require('./helpers').verifyDownloadedZip
 
 test('bad config test', (t) => {
-  const configPath = path.join(homePath(), '.config', 'npm', 'config')
+  const configPath = path.join(os.homedir(), '.config', 'npm', 'config')
   mkdirp(path.dirname(configPath))
   fs.writeFileSync(configPath, '{')
 


### PR DESCRIPTION
electron-builder, electron-packager and electron-osx-sign required node 4, so, we can 
* reduce number of dependencies and use `os.homedir()`,
* use babel preset `es2015-node4`.

Also, dependencies updated — fs-extra updated to 1.0.0.

`path-exists` updated to 3.0.0 — node <4 support is dropped (https://github.com/sindresorhus/path-exists/pull/4).