### PR TITLE
Catch npm rc parsing errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 const debug = require('debug')('electron-download')
 const fs = require('fs-extra')
 const homePath = require('home-path')
-const npmrc = require('rc')('npm')
+const rc = require('rc')
 const nugget = require('nugget')
 const os = require('os')
 const path = require('path')
@@ -14,6 +14,13 @@ const sumchecker = require('sumchecker')
 class ElectronDownloader {
   constructor (opts) {
     this.opts = opts
+
+    this.npmrc = {}
+    try {
+      rc('npm', this.npmrc)
+    } catch (error) {
+      console.error(`Error reading npm configuration: ${error.message}`)
+    }
   }
 
   get baseUrl () {
@@ -66,8 +73,8 @@ class ElectronDownloader {
 
   get proxy () {
     let proxy
-    if (npmrc && npmrc.proxy) proxy = npmrc.proxy
-    if (npmrc && npmrc['https-proxy']) proxy = npmrc['https-proxy']
+    if (this.npmrc && this.npmrc.proxy) proxy = this.npmrc.proxy
+    if (this.npmrc && this.npmrc['https-proxy']) proxy = this.npmrc['https-proxy']
 
     return proxy
   }
@@ -78,7 +85,7 @@ class ElectronDownloader {
 
   get strictSSL () {
     let strictSSL = true
-    if (this.opts.strictSSL === false || npmrc['strict-ssl'] === false) {
+    if (this.opts.strictSSL === false || this.npmrc['strict-ssl'] === false) {
       strictSSL = false
     }
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-config-standard": "^5.2.0",
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-standard": "^2.0.0",
+    "mkdirp": "^0.5.1",
     "tape": "^4.6.0"
   },
   "eslintConfig": {

--- a/test/test_bad_config.js
+++ b/test/test_bad_config.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const download = require('../lib/index')
+const fs = require('fs')
+const homePath = require('home-path')
+const mkdirp = require('mkdirp').sync
+const path = require('path')
+const test = require('tape')
+const verifyDownloadedZip = require('./helpers').verifyDownloadedZip
+
+test('bad config test', (t) => {
+  const configPath = path.join(homePath(), '.config', 'npm', 'config')
+  mkdirp(path.dirname(configPath))
+  fs.writeFileSync(configPath, '{')
+
+  download({
+    version: '0.25.1',
+    arch: 'ia32',
+    platform: 'win32',
+    quiet: true
+  }, (err, zipPath) => {
+    fs.unlinkSync(configPath)
+    verifyDownloadedZip(t, err, zipPath)
+    t.end()
+  })
+})


### PR DESCRIPTION
Looks like the `rc` library will throw errors for invalid JSON files but not include the file path being parsed.

This can make debugging hard since it looks in several location and it prevents Electron from being installed.

This pull request catches these errors and logs them but allows downloading to complete since the `npmrc` settings are often unused/optional and aren't required for installation.

Closes https://github.com/electron/electron/issues/8188