### PR TITLE
Support downloading other Electron assets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,20 @@ class ElectronDownloader {
   }
 
   get filename () {
-    return `electron-v${this.version}-${this.platform}-${this.arch}${this.symbols ? '-symbols' : ''}.zip`
+    const type = `${this.platform}-${this.arch}`
+    const suffix = `v${this.version}-${type}`
+
+    if (this.chromedriver) {
+      return `chromedriver-v2.21-${type}.zip`
+    } else if (this.mksnapshot) {
+      return `mksnapshot-${suffix}.zip`
+    } else if (this.ffmpeg) {
+      return `ffmpeg-${suffix}.zip`
+    } else if (this.symbols) {
+      return `electron-${suffix}-symbols.zip`
+    } else {
+      return `electron-${suffix}.zip`
+    }
   }
 
   get platform () {
@@ -94,6 +107,18 @@ class ElectronDownloader {
 
   get symbols () {
     return this.opts.symbols || false
+  }
+
+  get chromedriver () {
+    return this.opts.chromedriver || false
+  }
+
+  get mksnapshot () {
+    return this.opts.mksnapshot || false
+  }
+
+  get ffmpeg () {
+    return this.opts.ffmpeg || false
   }
 
   get url () {

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,12 @@ download({
 
 If you don't specify `arch` or `platform` args it will use the built-in `os` module to get the values from the current OS. Specifying `version` is mandatory. If there is a `SHASUMS256.txt` file available for the `version`, the file downloaded will be validated against its checksum to ensure that it was downloaded without errors.
 
+You can also use `electron-download` to download the `chromedriver`, `ffmpeg`,
+`mksnapshot`, and symbols assets for a specific Electron release. This can be
+configured by setting the `chromedriver`, `ffmpeg`, `mksnapshot`, or
+`symbols` property to `true` in the specified options object. Only one of
+these options may be specified per download call.
+
 If you would like to override the mirror location, three options are available. The mirror URL is composed as `url = ELECTRON_MIRROR + ELECTRON_CUSTOM_DIR + '/' + ELECTRON_CUSTOM_FILENAME`.
 
 You can set the `ELECTRON_MIRROR` or [`NPM_CONFIG_ELECTRON_MIRROR`](https://docs.npmjs.com/misc/config#environment-variables) environment variable or `mirror` opt variable to use a custom base URL for grabbing Electron zips. The same pattern applies to `ELECTRON_CUSTOM_DIR` and `ELECTRON_CUSTOM_FILENAME`:

--- a/test/test_chromedriver.js
+++ b/test/test_chromedriver.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const download = require('../lib/index')
+const path = require('path')
+const test = require('tape')
+const verifyDownloadedZip = require('./helpers').verifyDownloadedZip
+
+test('Chromedriver test', (t) => {
+  download({
+    version: '1.4.0',
+    arch: 'x64',
+    platform: 'darwin',
+    chromedriver: true,
+    quiet: true
+  }, (err, zipPath) => {
+    verifyDownloadedZip(t, err, zipPath)
+    t.ok(/^chromedriver-v2\.21-/.test(path.basename(zipPath)), 'Zip path should start with chromedriver-v.2.21')
+    t.end()
+  })
+})

--- a/test/test_ffmpeg.js
+++ b/test/test_ffmpeg.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const download = require('../lib/index')
+const path = require('path')
+const test = require('tape')
+const verifyDownloadedZip = require('./helpers').verifyDownloadedZip
+
+test('ffmpeg test', (t) => {
+  download({
+    version: '1.4.0',
+    arch: 'x64',
+    platform: 'darwin',
+    ffmpeg: true,
+    quiet: true
+  }, (err, zipPath) => {
+    verifyDownloadedZip(t, err, zipPath)
+    t.ok(/^ffmpeg-v1\.4\.0-/.test(path.basename(zipPath)), 'Zip path should start with ffmpeg-v1.4.0')
+    t.end()
+  })
+})

--- a/test/test_mksnapshot.js
+++ b/test/test_mksnapshot.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const download = require('../lib/index')
+const path = require('path')
+const test = require('tape')
+const verifyDownloadedZip = require('./helpers').verifyDownloadedZip
+
+test('mksnapshot test', (t) => {
+  download({
+    version: '1.4.0',
+    arch: 'x64',
+    platform: 'darwin',
+    mksnapshot: true,
+    quiet: true
+  }, (err, zipPath) => {
+    verifyDownloadedZip(t, err, zipPath)
+    t.ok(/^mksnapshot-v1\.4\.0-/.test(path.basename(zipPath)), 'Zip path should start with mksnapshot-v.1.4.0')
+    t.end()
+  })
+})


### PR DESCRIPTION
Currently only Electron and the symbols can be downloaded.

This pull request adds support for the Chromedriver, mksnapshot, and ffmpeg assets that are included in Electron releases.

This will be used by https://github.com/electron/chromedriver and https://github.com/electron/mksnapshot so they can consistently support proxies, shasum validation, logging, etc.