### PR TITLE
Add force option to redownload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,6 +105,10 @@ class ElectronDownloader {
     return strictSSL
   }
 
+  get force () {
+    return this.opts.force || false
+  }
+
   get symbols () {
     return this.opts.symbols || false
   }
@@ -135,7 +139,7 @@ class ElectronDownloader {
 
   checkForCachedChecksum (cb) {
     pathExists(this.cachedChecksum).then(exists => {
-      if (exists) {
+      if (exists && !this.force) {
         this.verifyChecksum(cb)
       } else if (this.tmpdir) {
         this.downloadChecksum(cb)
@@ -149,7 +153,7 @@ class ElectronDownloader {
 
   checkForCachedZip (cb) {
     pathExists(this.cachedZip).then(exists => {
-      if (exists) {
+      if (exists && !this.force) {
         debug('zip exists', this.cachedZip)
         this.checkIfZipNeedsVerifying(cb)
       } else {
@@ -245,9 +249,12 @@ class ElectronDownloader {
 
   moveFileToCache (filename, target, cb, onSuccess) {
     debug('moving', filename, 'from', this.tmpdir, 'to', target)
-    fs.move(path.join(this.tmpdir, filename), target, (err) => {
-      if (err) return cb(err)
-      onSuccess(cb)
+    fs.unlink(target, (err) => {
+      if (err != null && err.code !== 'ENOENT') return cb(err)
+      fs.move(path.join(this.tmpdir, filename), target, (err) => {
+        if (err) return cb(err)
+        onSuccess(cb)
+      })
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-standard": "^2.0.0",
     "mkdirp": "^0.5.1",
-    "tape": "^4.6.0"
+    "tape": "^4.6.0",
+    "temp": "^0.8.3"
   },
   "eslintConfig": {
     "extends": "standard",

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,9 @@ configured by setting the `chromedriver`, `ffmpeg`, `mksnapshot`, or
 `symbols` property to `true` in the specified options object. Only one of
 these options may be specified per download call.
 
+You can force a re-download of the asset and the `SHASUM` file by setting the
+`force` option to `true`.
+
 If you would like to override the mirror location, three options are available. The mirror URL is composed as `url = ELECTRON_MIRROR + ELECTRON_CUSTOM_DIR + '/' + ELECTRON_CUSTOM_FILENAME`.
 
 You can set the `ELECTRON_MIRROR` or [`NPM_CONFIG_ELECTRON_MIRROR`](https://docs.npmjs.com/misc/config#environment-variables) environment variable or `mirror` opt variable to use a custom base URL for grabbing Electron zips. The same pattern applies to `ELECTRON_CUSTOM_DIR` and `ELECTRON_CUSTOM_FILENAME`:

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,6 +4,9 @@ const fs = require('fs')
 
 exports.verifyDownloadedZip = (t, err, zipPath) => {
   t.error(err, 'Error should be null')
-  t.equal(fs.statSync(zipPath).isFile(), true, 'Zip path should exist')
-  t.notEqual(fs.statSync(zipPath).size, 0, 'Zip path should be non-empty')
+
+  if (err == null) {
+    t.equal(fs.statSync(zipPath).isFile(), true, 'Zip path should exist')
+    t.notEqual(fs.statSync(zipPath).size, 0, 'Zip path should be non-empty')
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const download = require('../lib/index')
+const fs = require('fs')
+const path = require('path')
+const temp = require('temp').track()
 const test = require('tape')
 const verifyDownloadedZip = require('./helpers').verifyDownloadedZip
 
@@ -9,6 +12,26 @@ test('Basic test', (t) => {
     version: '0.25.1',
     arch: 'ia32',
     platform: 'win32',
+    quiet: true
+  }, (err, zipPath) => {
+    verifyDownloadedZip(t, err, zipPath)
+    t.end()
+  })
+})
+
+test('Force option', (t) => {
+  const cachePath = temp.mkdirSync('electron-download-')
+
+  fs.writeFileSync(path.join(cachePath, 'ffmpeg-v1.4.13-win32-ia32.zip'), '')
+  fs.writeFileSync(path.join(cachePath, 'SHASUMS256.txt-1.4.13'), '')
+
+  download({
+    version: '1.4.13',
+    arch: 'ia32',
+    platform: 'win32',
+    ffmpeg: true,
+    cache: cachePath,
+    force: true,
     quiet: true
   }, (err, zipPath) => {
     verifyDownloadedZip(t, err, zipPath)


### PR DESCRIPTION
Add a `force` boolean option that when set will re-download the asset and the `SHASUM` file to the cache area.

/cc @pfrazee would this option work for your use case?

Closes #38 