### PR TITLE
Remove Node 0.12 support and Babel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 .DS_Store
-build
 npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,4 @@
 .travis.yml
 appveyor.yml
 test
-lib
 npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
 - '4'
 - '5'
 - '6'
+- '7'
 cache:
 - directories:
   - "$HOME/.npm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ os:
 osx_image: xcode7.3
 language: node_js
 node_js:
-- '0.10'
-- '0.12'
 - '4'
 - '5'
 - '6'
@@ -16,9 +14,3 @@ cache:
 branches:
   only:
   - master
-before_install:
-  - nvm install stable
-script:
-  - npm run lint
-  - nvm use $TRAVIS_NODE_VERSION
-  - npm run unit-tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ environment:
   - nodejs_version: "4"
   - nodejs_version: "5"
   - nodejs_version: "6"
+  - nodejs_version: "7"
 
 skip_tags: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,6 @@ branches:
 
 environment:
   matrix:
-  - nodejs_version: "0.10"
-  - nodejs_version: "0.12"
   - nodejs_version: "4"
   - nodejs_version: "5"
   - nodejs_version: "6"

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@
 
 const debug = require('debug')('electron-download')
 const fs = require('fs-extra')
-const homePath = require('home-path')
 const rc = require('rc')
 const nugget = require('nugget')
 const os = require('os')
@@ -44,7 +43,7 @@ class ElectronDownloader {
   }
 
   get cache () {
-    return this.opts.cache || path.join(homePath(), './.electron')
+    return this.opts.cache || path.join(os.homedir(), './.electron')
   }
 
   get cachedChecksum () {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "debug": "^2.2.0",
     "fs-extra": "^2.0.0",
-    "home-path": "^1.0.1",
     "minimist": "^1.2.0",
     "nugget": "^2.0.0",
     "path-exists": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
   "homepage": "https://github.com/electron-userland/electron-download#readme",
   "dependencies": {
     "debug": "^2.2.0",
-    "fs-extra": "^0.30.0",
+    "fs-extra": "^2.0.0",
     "home-path": "^1.0.1",
     "minimist": "^1.2.0",
     "nugget": "^2.0.0",
-    "path-exists": "^2.1.0",
+    "path-exists": "^3.0.0",
     "rc": "^1.1.2",
     "semver": "^5.3.0",
-    "sumchecker": "^1.2.0"
+    "sumchecker": "^2.0.1"
   },
   "devDependencies": {
     "eslint": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,13 @@
   "name": "electron-download",
   "version": "3.2.0",
   "description": "download electron prebuilt binary zips from github releases",
-  "main": "build/index.js",
+  "main": "lib/index.js",
   "bin": {
-    "electron-download": "build/cli.js"
+    "electron-download": "lib/cli.js"
   },
   "scripts": {
-    "prepublish": "babel --out-dir build lib",
     "lint": "eslint lib test",
-    "unit-tests": "tape -r babel-register test/*.js",
+    "unit-tests": "tape test/*.js",
     "test": "npm run unit-tests && npm run lint"
   },
   "repository": {
@@ -34,9 +33,6 @@
     "sumchecker": "^1.2.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.14.0",
-    "babel-preset-es2015": "^6.14.0",
-    "babel-register": "^6.14.0",
     "eslint": "^3.2.0",
     "eslint-config-standard": "^5.2.0",
     "eslint-plugin-promise": "^2.0.0",
@@ -56,10 +52,8 @@
       ]
     }
   },
-  "babel": {
-    "presets": [
-      "es2015"
-    ]
-  },
-  "keywords": []
+  "keywords": [],
+  "engines": {
+    "node": ">= 4.0"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -12,13 +12,15 @@ Used by [electron-prebuilt](https://npmjs.org/electron-prebuilt) and [electron-p
 
 ### Usage
 
+**Note: Requires Node >= 4.0 to run.**
+
 ```shell
 $ npm install --global electron-download
 $ electron-download --version=0.31.1
 ```
 
 ```javascript
-var download = require('electron-download')
+const download = require('electron-download')
 
 download({
   version: '0.25.1',

--- a/test/test_bad_config.js
+++ b/test/test_bad_config.js
@@ -2,14 +2,14 @@
 
 const download = require('../lib/index')
 const fs = require('fs')
-const homePath = require('home-path')
 const mkdirp = require('mkdirp').sync
+const os = require('os')
 const path = require('path')
 const test = require('tape')
 const verifyDownloadedZip = require('./helpers').verifyDownloadedZip
 
 test('bad config test', (t) => {
-  const configPath = path.join(homePath(), '.config', 'npm', 'config')
+  const configPath = path.join(os.homedir(), '.config', 'npm', 'config')
   mkdirp(path.dirname(configPath))
   fs.writeFileSync(configPath, '{')
 


### PR DESCRIPTION
Hopefully this goes a bit better than when I removed both of these things from sumchecker.

Per the policy, this will require a major version bump.

Closes #40.