### PR TITLE
mirror that works

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const debug = require('debug')('electron-download')
 const envPaths = require('env-paths')
 const fs = require('fs-extra')
 const rc = require('rc')
-const nugget = require('nugget')
+const request = require('request')
 const os = require('os')
 const path = require('path')
 const pathExists = require('path-exists')
@@ -142,7 +142,10 @@ class ElectronDownloader {
   }
 
   get verifyChecksumNeeded () {
-    return semver.gte(this.version, '1.3.2')
+    return !(this.opts.electron_no_checksum === true ||
+      this.npmrc.electron_no_checksum === 'true' ||
+      process.env.ELECTRON_NO_CHECKSUM === 'true' ||
+      semver.lt(this.version, '1.3.2'))
   }
 
   get version () {
@@ -211,22 +214,43 @@ class ElectronDownloader {
 
   downloadFile (url, filename, cacheFilename, cb, onSuccess) {
     debug('downloading', url, 'to', this.tmpdir)
-    let nuggetOpts = {
-      target: filename,
-      dir: this.tmpdir,
-      resume: true,
-      quiet: this.quiet,
+    let requestOpts = {
+      uri: url,
       strictSSL: this.strictSSL,
       proxy: this.proxy
     }
-    nugget(url, nuggetOpts, (errors) => {
-      if (errors) {
-        // nugget returns an array of errors but we only need 1st because we only have 1 url
-        return this.handleDownloadError(cb, errors[0])
-      }
-
-      this.moveFileToCache(filename, cacheFilename, cb, onSuccess)
-    })
+    if (!this.quiet) {
+      request.debug = true
+    }
+    var gotError = false
+    var dest = path.join(this.tmpdir, filename)
+    var file = fs.createWriteStream(dest)
+      .on('error', error => { this.handleDownloadError(cb, error) })
+    var req = request(requestOpts)
+    req
+      .on('response', response => {
+        if (response.statusCode >= 400) {
+          gotError = true
+          fs.unlink(dest, err => {
+            let errorMsg = err || { message: response.statusCode + '' }
+            this.handleDownloadError(cb, errorMsg)
+          })
+          req.abort()
+        }
+      })
+      .on('error', error => {
+        gotError = true
+        fs.unlink(dest, err => {
+          let errorMsg = err || error
+          this.handleDownloadError(cb, errorMsg)
+        })
+      })
+      .on('end', _ => {
+        if (!gotError) {
+          this.moveFileToCache(filename, cacheFilename, cb, onSuccess)
+        }
+      })
+      .pipe(file)
   }
 
   downloadIfNotCached (cb) {
@@ -255,7 +279,6 @@ class ElectronDownloader {
     } else {
       error.message = `Failed to find Electron v${this.version} for ${this.platform}-${this.arch} at ${this.url}`
     }
-
     return cb(error)
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ const path = require('path')
 const pathExists = require('path-exists')
 const semver = require('semver')
 const sumchecker = require('sumchecker')
+const Progress = require('progress')
 
 class ElectronDownloader {
   constructor (opts) {
@@ -223,12 +224,24 @@ class ElectronDownloader {
       request.debug = true
     }
     var gotError = false
+    var progress = null
     var dest = path.join(this.tmpdir, filename)
     var file = fs.createWriteStream(dest)
       .on('error', error => { this.handleDownloadError(cb, error) })
     var req = request(requestOpts)
     req
       .on('response', response => {
+        try {
+          var len = parseInt(response.headers['content-length'], 10)
+          console.log()
+          progress = new Progress(`Downloading Electron ${this.version} [:bar] (:percent)`, {
+            width: 30,
+            total: len
+          })
+        } catch (err) {
+          debug(err.message)
+        }
+
         if (response.statusCode >= 400) {
           gotError = true
           fs.unlink(dest, err => {
@@ -249,6 +262,9 @@ class ElectronDownloader {
         if (!gotError) {
           this.moveFileToCache(filename, cacheFilename, cb, onSuccess)
         }
+      })
+      .on('data', chunk => {
+        if (progress) progress.tick(chunk.length)
       })
       .pipe(file)
   }

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "env-paths": "^1.0.0",
     "fs-extra": "^2.0.0",
     "minimist": "^1.2.0",
-    "nugget": "^2.0.0",
     "path-exists": "^3.0.0",
     "rc": "^1.1.2",
+    "request": "^2.81.0",
     "semver": "^5.3.0",
     "sumchecker": "^2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "fs-extra": "^2.0.0",
     "minimist": "^1.2.0",
     "path-exists": "^3.0.0",
+    "progress": "^2.0.0",
     "rc": "^1.1.2",
     "request": "^2.81.0",
     "semver": "^5.3.0",

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,8 @@ ELECTRON_MIRROR="https://10.1.2.105/"
 ELECTRON_CUSTOM_DIR="our/internal/filePath"
 ```
 
+You can also disable checksum verification with environment variable ELECTRON_NO_CHECKSUM set to "true".
+
 You can set ELECTRON_MIRROR in `.npmrc` as well, using the lowercase name:
 
 ```plain

--- a/test/test_custom_uri.js
+++ b/test/test_custom_uri.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const test = require('tape')
+const verifyDownloadedZip = require('./helpers').verifyDownloadedZip
+
+test('Chromedriver test', (t) => {
+  process.env.ELECTRON_MIRROR = 'https://github.com'
+  process.env.ELECTRON_CUSTOM_DIR = '/electron-userland/electron-download/archive'
+  process.env.ELECTRON_CUSTOM_FILENAME = 'v4.0.0.zip'
+  process.env.ELECTRON_NO_CHECKSUM = 'true'
+  const download = require('../lib/index')
+  download({
+    cache: process.env.electron_config_cache,
+    version: '4.0.0',
+    platform: process.env.npm_config_platform,
+    arch: process.env.npm_config_arch,
+    strictSSL: process.env.npm_config_strict_ssl === 'true',
+    quiet: ['info', 'verbose', 'silly', 'http'].indexOf(process.env.npm_config_loglevel) === -1
+  }, (err, zipPath) => {
+    verifyDownloadedZip(t, err, zipPath)
+    process.env.ELECTRON_MIRROR = ''
+    process.env.ELECTRON_CUSTOM_DIR = ''
+    process.env.ELECTRON_CUSTOM_FILENAME = ''
+    process.env.ELECTRON_NO_CHECKSUM = ''
+    t.end()
+  })
+})


### PR DESCRIPTION
- **fix follow redirect**
I replaced nugget by request which is more robust. nugget considers all http response code above 299 to be errors...it's not the case!!
fix https://github.com/electron-userland/electron-download/issues/49
- **allow mirror to not host a checksum**
at work I really cannot host on our common repository the sha. I cannot download electron's sha neither from an outside url
fix https://github.com/electron-userland/electron-download/issues/51