### PR TITLE
Fix fallback location

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,13 +44,14 @@ class ElectronDownloader {
   }
 
   get cache () {
+    if (this.opts.cache) return this.opts.cache
+
     const oldCacheDirectory = path.join(os.homedir(), './.electron')
     if (pathExists.sync(path.join(oldCacheDirectory, this.filename))) {
-      return path.join(os.homedir(), './.electron')
+      return oldCacheDirectory
     }
-
     // use passed argument or XDG environment variable fallback to OS default
-    return this.opts.cache || envPaths('electron', {suffix: ''}).cache
+    return envPaths('electron', {suffix: ''}).cache
   }
 
   get cachedChecksum () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,11 @@ class ElectronDownloader {
   }
 
   get cache () {
+    const oldCacheDirectory = path.join(os.homedir(), './.electron')
+    if (pathExists.sync(path.join(oldCacheDirectory, this.filename))) {
+      return path.join(os.homedir(), './.electron')
+    }
+
     // use passed argument or XDG environment variable fallback to OS default
     return this.opts.cache || envPaths('electron', {suffix: ''}).cache
   }
@@ -53,11 +58,6 @@ class ElectronDownloader {
   }
 
   get cachedZip () {
-    const oldLocation = path.join(os.homedir(), './.electron', this.filename)
-    if (pathExists.sync(oldLocation)) {
-      return oldLocation
-    }
-
     return path.join(this.cache, this.filename)
   }
 

--- a/test/test_fallback.js
+++ b/test/test_fallback.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const download = require('../lib/index')
+const os = require('os')
+const path = require('path')
+const test = require('tape')
+const verifyDownloadedZip = require('./helpers').verifyDownloadedZip
+
+test('Cached version above version 1.3.2 is used as fallback', (t) => {
+  const oldCachePath = path.join(os.homedir(), './.electron')
+  const downloadOptions = {
+    version: '1.6.2',
+    arch: 'x64',
+    platform: 'linux',
+    quiet: true
+  }
+
+  download(
+    Object.assign(
+      {},
+      downloadOptions,
+      { cache: oldCachePath }
+    ),
+    (err, zipPath) => {
+      t.notOk(err, 'No error should occur')
+
+      download(downloadOptions, (err, zipPath) => {
+        verifyDownloadedZip(t, err, zipPath)
+        t.end()
+      })
+    }
+  )
+})

--- a/test/test_fallback.js
+++ b/test/test_fallback.js
@@ -5,9 +5,9 @@ const os = require('os')
 const path = require('path')
 const test = require('tape')
 const verifyDownloadedZip = require('./helpers').verifyDownloadedZip
+const oldCachePath = path.join(os.homedir(), './.electron')
 
 test('Cached version above version 1.3.2 is used as fallback', (t) => {
-  const oldCachePath = path.join(os.homedir(), './.electron')
   const downloadOptions = {
     version: '1.6.2',
     arch: 'x64',
@@ -16,18 +16,41 @@ test('Cached version above version 1.3.2 is used as fallback', (t) => {
   }
 
   download(
-    Object.assign(
-      {},
-      downloadOptions,
-      { cache: oldCachePath }
-    ),
+    Object.assign({}, downloadOptions, { cache: oldCachePath }),
     (err, zipPath) => {
       t.notOk(err, 'No error should occur')
 
       download(downloadOptions, (err, zipPath) => {
-        verifyDownloadedZip(t, err, zipPath)
+        const expectedPath = path.join(oldCachePath, path.basename(zipPath))
+        verifyDownloadedZip(t, err, expectedPath)
         t.end()
       })
+    }
+  )
+})
+
+test('Passed cache location has priority above fallback location', (t) => {
+  const downloadOptions = {
+    version: '1.6.2',
+    arch: 'x64',
+    platform: 'linux',
+    quiet: true
+  }
+
+  download(
+    Object.assign({}, downloadOptions, { cache: oldCachePath }),
+    (err, zipPath) => {
+      t.notOk(err, 'No error should occur')
+
+      download(
+        Object.assign({}, downloadOptions, { cache: os.tmpdir() }),
+        (err, zipPath) => {
+          const expectedPath = path.join(os.tmpdir(), path.basename(zipPath))
+          t.equal(zipPath, expectedPath)
+          verifyDownloadedZip(t, err, expectedPath)
+          t.end()
+        }
+      )
     }
   )
 })


### PR DESCRIPTION
See @develar's concerns at the original issue #24 and at the [atomic rename PR](https://github.com/electron-userland/electron-download/pull/47#issuecomment-292803245).

I have included a test that fails against master and is passing by moving the fallback logic to directory level.