### PR TITLE
Remove fallback location and document how to migrate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,11 +53,6 @@ class ElectronDownloader {
   }
 
   get cachedZip () {
-    const oldLocation = path.join(os.homedir(), './.electron', this.filename)
-    if (pathExists.sync(oldLocation)) {
-      return oldLocation
-    }
-
     return path.join(this.cache, this.filename)
   }
 

--- a/readme.md
+++ b/readme.md
@@ -66,8 +66,12 @@ electron_mirror=https://10.1.2.105/
 ```
 
 ### Cache location
+
 The location of the cache depends on the operating system, the defaults are:
 - Linux: `$XDG_CACHE_HOME` or `~/.cache/electron/`
 - MacOS: `~/Library/Caches/electron/`
 - Windows: `$LOCALAPPDATA/electron/Cache` or `~/AppData/Local/electron/Cache/`
 
+**Note:** In previous releases `~/.electron` was used as the cache location.
+You can move the files in that folder to the new locations mentioned above
+to reuse the cached assets.


### PR DESCRIPTION
Instead of supporting a fallback location to the old cache directory, this pull request removes it and just documents how people can move it over.

It seems worthwhile to just do a clean break here to simplify the code and have consistent behavior in terms of where assets are pull from.

Refs #54 
Refs #37

/cc @malept @Siilwyn 