### PR TITLE
Electron cache env

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,7 +5,7 @@
 const download = require('./')
 const minimist = require('minimist')
 
-let opts = minimist(process.argv.slice(2))
+const opts = minimist(process.argv.slice(2))
 
 if (opts['strict-ssl'] === false) {
   opts.strictSSL = false

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ class ElectronDownloader {
   }
 
   get cache () {
-    let cacheLocation = this.opts.cache || process.env.ELECTRON_CACHE
+    const cacheLocation = this.opts.cache || process.env.ELECTRON_CACHE
     if (cacheLocation) return cacheLocation
 
     const oldCacheDirectory = path.join(os.homedir(), './.electron')
@@ -191,7 +191,7 @@ class ElectronDownloader {
       if (err) {
         if (err.code !== 'EACCES') return cb(err)
         // try local folder if homedir is off limits (e.g. some linuxes return '/' as homedir)
-        let localCache = path.resolve('./.electron')
+        const localCache = path.resolve('./.electron')
         return fs.mkdirs(localCache, function (err) {
           if (err) return cb(err)
           cb(null, localCache)
@@ -208,7 +208,7 @@ class ElectronDownloader {
   downloadFile (url, cacheFilename, cb, onSuccess) {
     const tempFileName = `tmp-${process.pid}-${(ElectronDownloader.tmpFileCounter++).toString(16)}-${path.basename(cacheFilename)}`
     debug('downloading', url, 'to', this.cache)
-    let nuggetOpts = {
+    const nuggetOpts = {
       target: tempFileName,
       dir: this.cache,
       resume: true,
@@ -277,11 +277,11 @@ class ElectronDownloader {
   }
 
   verifyChecksum (cb) {
-    let options = {}
+    const options = {}
     if (semver.lt(this.version, '1.3.5')) {
       options.defaultTextEncoding = 'binary'
     }
-    let checker = new sumchecker.ChecksumValidator('sha256', this.cachedChecksum, options)
+    const checker = new sumchecker.ChecksumValidator('sha256', this.cachedChecksum, options)
     checker.validate(this.cache, this.filename).then(() => {
       cb(null, this.cachedZip)
     }, (err) => {
@@ -296,6 +296,6 @@ class ElectronDownloader {
 ElectronDownloader.tmpFileCounter = 0
 
 module.exports = function download (opts, cb) {
-  let downloader = new ElectronDownloader(opts)
+  const downloader = new ElectronDownloader(opts)
   downloader.downloadIfNotCached(cb)
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,8 @@ class ElectronDownloader {
   }
 
   get cache () {
-    if (this.opts.cache) return this.opts.cache
+    let cacheLocation = this.opts.cache || process.env.ELECTRON_CACHE
+    if (cacheLocation) return cacheLocation
 
     const oldCacheDirectory = path.join(os.homedir(), './.electron')
     if (pathExists.sync(path.join(oldCacheDirectory, this.filename))) {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "rules": {
       "strict": [
         "error"
+      ],
+      "prefer-const": [
+        "error"
       ]
     }
   },

--- a/readme.md
+++ b/readme.md
@@ -71,3 +71,5 @@ The location of the cache depends on the operating system, the defaults are:
 - MacOS: `~/Library/Caches/electron/`
 - Windows: `$LOCALAPPDATA/electron/Cache` or `~/AppData/Local/electron/Cache/`
 
+You can set the `ELECTRON_CACHE` environment variable to set cache location explicitely.
+

--- a/readme.md
+++ b/readme.md
@@ -71,5 +71,5 @@ The location of the cache depends on the operating system, the defaults are:
 - MacOS: `~/Library/Caches/electron/`
 - Windows: `$LOCALAPPDATA/electron/Cache` or `~/AppData/Local/electron/Cache/`
 
-You can set the `ELECTRON_CACHE` environment variable to set cache location explicitely.
+You can set the `ELECTRON_CACHE` environment variable to set cache location explicitly.
 


### PR DESCRIPTION
Because on CI server system-specific location (multi CI like Travis allows) complicates cache configuration.