### PR TITLE
get baseUrl, middleUrl and filename from package

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,28 +24,28 @@ class ElectronDownloader {
   }
 
   get baseUrl () {
-    return process.env.ELECTRON_MIRROR ||
-      process.env.npm_package_config_electron_mirror ||
+    return process.env.NPM_CONFIG_ELECTRON_MIRROR ||
       process.env.npm_config_electron_mirror ||
-      process.env.NPM_CONFIG_ELECTRON_MIRROR ||
+      process.env.npm_package_config_electron_mirror ||
+      process.env.ELECTRON_MIRROR ||
       this.opts.mirror ||
       'https://github.com/electron/electron/releases/download/v'
   }
 
   get middleUrl () {
-    return process.env.ELECTRON_CUSTOM_DIR ||
+    return process.env.NPM_CONFIG_ELECTRON_CUSTOM_DIR ||
       process.env.npm_config_electron_custom_dir ||
-      process.env.NPM_CONFIG_ELECTRON_CUSTOM_DIR ||
       process.env.npm_package_config_electron_custom_dir ||
+      process.env.ELECTRON_CUSTOM_DIR ||
       this.opts.customDir ||
       this.version
   }
 
   get urlSuffix () {
-    return process.env.ELECTRON_CUSTOM_FILENAME ||
+    return process.env.NPM_CONFIG_ELECTRON_CUSTOM_FILENAME ||
       process.env.npm_config_electron_custom_filename ||
-      process.env.NPM_CONFIG_ELECTRON_CUSTOM_FILENAME ||
       process.env.npm_package_config_electron_custom_filename ||
+      process.env.ELECTRON_CUSTOM_FILENAME ||
       this.opts.customFilename ||
       this.filename
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,19 +24,30 @@ class ElectronDownloader {
   }
 
   get baseUrl () {
-    return process.env.NPM_CONFIG_ELECTRON_MIRROR ||
+    return process.env.ELECTRON_MIRROR ||
+      process.env.npm_package_config_electron_mirror ||
       process.env.npm_config_electron_mirror ||
-      process.env.ELECTRON_MIRROR ||
+      process.env.NPM_CONFIG_ELECTRON_MIRROR ||
       this.opts.mirror ||
       'https://github.com/electron/electron/releases/download/v'
   }
 
   get middleUrl () {
-    return process.env.ELECTRON_CUSTOM_DIR || this.opts.customDir || this.version
+    return process.env.ELECTRON_CUSTOM_DIR ||
+      process.env.npm_config_electron_custom_dir ||
+      process.env.NPM_CONFIG_ELECTRON_CUSTOM_DIR ||
+      process.env.npm_package_config_electron_custom_dir ||
+      this.opts.customDir ||
+      this.version
   }
 
   get urlSuffix () {
-    return process.env.ELECTRON_CUSTOM_FILENAME || this.opts.customFilename || this.filename
+    return process.env.ELECTRON_CUSTOM_FILENAME ||
+      process.env.npm_config_electron_custom_filename ||
+      process.env.NPM_CONFIG_ELECTRON_CUSTOM_FILENAME ||
+      process.env.npm_package_config_electron_custom_filename ||
+      this.opts.customFilename ||
+      this.filename
   }
 
   get arch () {

--- a/readme.md
+++ b/readme.md
@@ -57,13 +57,38 @@ ELECTRON_MIRROR="https://npm.taobao.org/mirrors/electron/"
 ## or for a local mirror
 ELECTRON_MIRROR="https://10.1.2.105/"
 ELECTRON_CUSTOM_DIR="our/internal/filePath"
+ELECTRON_CUSTOM_FILENAME="electron.zip"
 ```
 
 You can set ELECTRON_MIRROR in `.npmrc` as well, using the lowercase name:
 
 ```plain
 electron_mirror=https://10.1.2.105/
+electron_custom_dir="our/internal/filePath"
+electron_custom_filename="electron.zip"
 ```
+
+You can also set the same variables in your project's package.json:
+
+```json
+{
+    "name" : "my-electron-project",
+    "config" : {
+        "electron_mirror": "https://10.1.2.105/",
+        "electron_custom_dir": "our/internal/filePath",
+        "electron_custom_filename": "electron.zip"
+    }
+}
+```
+
+The order of precedence is:
+
+1. environment variables (`process.env.ELECTRON_*`)
+1. npm config or .npmrc (`process.env.npm_config_electron_*`)
+1. npm config or .npmrc, but uppercase (`process.env.NPM_PACKAGE_CONFIG_ELECTRON_*`)
+1. package.json (`process.env.npm_package_config_electron_*`)
+1. the options given to `download`
+1. defaults
 
 ### Cache location
 The location of the cache depends on the operating system, the defaults are:

--- a/readme.md
+++ b/readme.md
@@ -83,10 +83,10 @@ You can also set the same variables in your project's package.json:
 
 The order of precedence is:
 
-1. environment variables (`process.env.ELECTRON_*`)
-1. npm config or .npmrc (`process.env.npm_config_electron_*`)
-1. npm config or .npmrc, but uppercase (`process.env.NPM_PACKAGE_CONFIG_ELECTRON_*`)
+1. npm config or .npmrc, uppercase (`process.env.NPM_CONFIG_ELECTRON_*`)
+1. npm config or .npmrc, lowercase(`process.env.npm_config_electron_*`)
 1. package.json (`process.env.npm_package_config_electron_*`)
+1. environment variables (`process.env.ELECTRON_*`)
 1. the options given to `download`
 1. defaults
 


### PR DESCRIPTION
There were some inconsistencies here; you could specify the mirror base URL in npm config and .npmrc, but not middleUrl or urlSuffix (filename). This change rectifies that and allows you to specify baseUrl, middleUrl and urlSuffix in the consuming project's [package.json `config` block](https://docs.npmjs.com/files/package.json#config)