### PR TITLE
Add option to download PDB archive

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,6 +104,8 @@ class ElectronDownloader {
       return `electron-${suffix}-symbols.zip`
     } else if (this.dsym) {
       return `electron-${suffix}-dsym.zip`
+    } else if (this.pdb) {
+      return `electron-${suffix}-pdb.zip`;
     } else {
       return `electron-${suffix}.zip`
     }
@@ -144,6 +146,10 @@ class ElectronDownloader {
 
   get dsym () {
     return this.opts.dsym || false
+  }
+
+  get pdb() {
+    return this.opts.pdb || false
   }
 
   get chromedriver () {

--- a/readme.md
+++ b/readme.md
@@ -39,8 +39,8 @@ If you don't specify `arch` or `platform` args it will use the built-in `os` mod
 
 You can also use `electron-download` to download the `chromedriver`, `ffmpeg`,
 `mksnapshot`, and symbols assets for a specific Electron release. This can be
-configured by setting the `chromedriver`, `ffmpeg`, `mksnapshot`, or
-`symbols` property to `true` in the specified options object. Only one of
+configured by setting the `chromedriver`, `ffmpeg`, `mksnapshot`, `pdb`, `dsym`,
+or `symbols` property to `true` in the specified options object. Only one of
 these options may be specified per download call.
 
 You can force a re-download of the asset and the `SHASUM` file by setting the

--- a/test/test_pdb.js
+++ b/test/test_pdb.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const download = require("../lib/index");
+const test = require("tape");
+const verifyDownloadedZip = require("./helpers").verifyDownloadedZip;
+
+test("PDB test", t => {
+  download(
+    {
+      version: "1.4.15",
+      arch: "x64",
+      platform: "win32",
+      pdb: true,
+      quiet: true
+    },
+    (err, zipPath) => {
+      verifyDownloadedZip(t, err, zipPath);
+      t.ok(/-pdb\.zip$/.test(zipPath), "Zip path should end with -pdb.zip");
+      t.end();
+    }
+  );
+});


### PR DESCRIPTION
Similar to the `dsym` option, this adds an option to download PDBs. This is the most straight-forward implementation, though, It might make sense to unify these flags to something like:

`type: 'binary' (default) | 'symbols' | 'dsym' | 'pdb'`