### PR TITLE
Determine arch on ARM hosts better

### DIFF
--- a/lib/arch.js
+++ b/lib/arch.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const execSync = require('child_process').execSync
+
+module.exports = {
+  host: function host (quiet) {
+    const arch = process.arch
+    if (arch === 'arm') {
+      switch (process.config.variables.arm_version) {
+        case '6':
+          return module.exports.uname()
+        case '7':
+          return 'armv7l'
+        default:
+          if (!quiet) {
+            console.warn(`WARNING: Could not determine specific ARM arch. Detected ARM version: ${JSON.stringify(process.config.variables.arm_version)}`)
+          }
+      }
+    }
+
+    return arch
+  },
+
+  /**
+   * Returns the arch name from the `uname` utility.
+   */
+  uname: function uname () {
+    return execSync('uname -m').toString().trim()
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const arch = require('./arch')
 const debug = require('debug')('electron-download')
 const envPaths = require('env-paths')
 const fs = require('fs-extra')
@@ -54,7 +55,7 @@ class ElectronDownloader {
   }
 
   get arch () {
-    return this.opts.arch || os.arch()
+    return this.opts.arch || arch.host(this.quiet)
   }
 
   get cache () {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
+    "sinon": "^6.1.4",
     "tape": "^4.8.0",
     "temp": "^0.8.3"
   },

--- a/test/test_arch.js
+++ b/test/test_arch.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const arch = require('../lib/arch')
+const sinon = require('sinon')
+const test = require('tape')
+
+test('hostArch detects incorrectly configured armv7l Node', t => {
+  sinon.stub(arch, 'uname').returns('armv6l')
+  sinon.stub(process, 'arch').value('arm')
+  sinon.stub(process, 'config').value({variables: {arm_version: '6'}})
+
+  t.is(arch.host(), 'armv6l')
+
+  sinon.restore()
+  t.end()
+})
+
+test('hostArch detects correctly configured armv7l Node', t => {
+  sinon.stub(process, 'arch').value('arm')
+  sinon.stub(process, 'config').value({variables: {arm_version: '7'}})
+
+  t.is(arch.host(), 'armv7l')
+
+  sinon.restore()
+  t.end()
+})
+
+test('hostArch cannot determine ARM version', t => {
+  sinon.stub(process, 'arch').value('arm')
+  sinon.stub(process, 'config').value({variables: {arm_version: '99'}})
+
+  t.is(arch.host(), 'arm')
+
+  sinon.restore()
+  t.end()
+})


### PR DESCRIPTION
Determine which specific ARM version a given host arch is running, so the appropriate Electron binary is selected. This is particularly important as of Electron 3, since `-arm` builds are no longer being created.

This basically moves `hostArch` from Electron Packager into this package.

Fixes https://github.com/electron/electron/issues/13745.