### PR TITLE
 Convert to use Promises

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,27 +4,18 @@ const arch = require('./arch')
 const debug = require('debug')('electron-download')
 const envPaths = require('env-paths')
 const fs = require('fs-extra')
-const rc = require('rc')
+const nodeify = require('nodeify')
 const nugget = require('nugget')
 const os = require('os')
 const path = require('path')
-const pathExists = require('path-exists')
+const pify = require('pify')
+const rc = require('rc')
 const semver = require('semver')
 const sumchecker = require('sumchecker')
 
 class ElectronDownloader {
   constructor (opts) {
     this.opts = Object.assign({ autoDownload: true }, opts)
-    if (this.opts.force && !this.opts.autoDownload) {
-      throw new Error('force and autoDownload options are incompatible for Electron Download')
-    }
-
-    this.npmrc = {}
-    try {
-      rc('npm', this.npmrc)
-    } catch (error) {
-      console.error(`Error reading npm configuration: ${error.message}`)
-    }
   }
 
   get baseUrl () {
@@ -71,7 +62,7 @@ class ElectronDownloader {
     if (cacheLocation) return cacheLocation
 
     const oldCacheDirectory = path.join(os.homedir(), './.electron')
-    if (pathExists.sync(path.join(oldCacheDirectory, this.filename))) {
+    if (fs.pathExistsSync(path.join(oldCacheDirectory, this.filename))) {
       return oldCacheDirectory
     }
     // use passed argument or XDG environment variable fallback to OS default
@@ -184,60 +175,77 @@ class ElectronDownloader {
     return this.opts.headers
   }
 
-  checkForCachedChecksum (cb) {
-    pathExists(this.cachedChecksum)
+  validateOptions () {
+    return new Promise((resolve, reject) => {
+      if (this.opts.force && !this.opts.autoDownload) {
+        reject(new Error('force and autoDownload options are incompatible for Electron Download'))
+      }
+
+      this.npmrc = {}
+      try {
+        rc('npm', this.npmrc)
+      } catch (error) {
+        console.error(`Error reading npm configuration: ${error.message}`)
+      }
+
+      resolve()
+    })
+  }
+
+  checkForCachedChecksum () {
+    return fs.pathExists(this.cachedChecksum)
       .then(exists => {
         if (exists && !this.force) {
-          this.verifyChecksum(cb)
+          return this.verifyChecksum()
         } else {
-          this.downloadChecksum(cb)
+          return this.downloadChecksum()
         }
       })
   }
 
-  checkForCachedZip (cb) {
-    pathExists(this.cachedZip).then(exists => {
+  checkForCachedZip () {
+    return fs.pathExists(this.cachedZip).then(exists => {
       if (exists && !this.force) {
         debug('zip exists', this.cachedZip)
-        this.checkIfZipNeedsVerifying(cb)
+        return this.checkIfZipNeedsVerifying()
       } else if (this.opts.autoDownload) {
-        this.ensureCacheDir(cb)
+        return this.ensureCacheDir()
       } else {
-        cb(new Error(`File: "${this.cachedZip}" does not exist locally and autoDownload is false`))
+        throw new Error(`File: "${this.cachedZip}" does not exist locally and autoDownload is false`)
       }
     })
   }
 
-  checkIfZipNeedsVerifying (cb) {
+  checkIfZipNeedsVerifying () {
     if (this.verifyChecksumNeeded) {
       debug('Verifying zip with checksum')
-      return this.checkForCachedChecksum(cb)
+      return this.checkForCachedChecksum()
     }
-    return cb(null, this.cachedZip)
+    return this.cachedZip
   }
 
-  createCacheDir (cb) {
-    fs.mkdirs(this.cache, (err) => {
-      if (err) {
-        if (err.code !== 'EACCES') return cb(err)
-        // try local folder if homedir is off limits (e.g. some linuxes return '/' as homedir)
-        const localCache = path.resolve('./.electron')
-        return fs.mkdirs(localCache, function (err) {
-          if (err) return cb(err)
-          cb(null, localCache)
-        })
-      }
-      cb(null, this.cache)
-    })
+  createLocalCacheDir () {
+    // try local folder if homedir is off limits (e.g. some linuxes return '/' as homedir)
+    const localCache = path.resolve('./.electron')
+    return fs.mkdirs(localCache)
+      .then(() => localCache)
   }
 
-  downloadChecksum (cb) {
-    this.downloadFile(this.checksumUrl, this.cachedChecksum, cb, this.verifyChecksum.bind(this))
+  createCacheDir () {
+    return fs.mkdirs(this.cache)
+      .catch(err => {
+        if (err.code !== 'EACCES') throw err
+        return this.createLocalCacheDir()
+      }).then(cache => cache || this.cache)
   }
 
-  downloadFile (url, cacheFilename, cb, onSuccess) {
+  downloadChecksum () {
+    return this.downloadFile(this.checksumUrl, this.cachedChecksum)
+      .then(() => this.verifyChecksum())
+  }
+
+  downloadFile (url, cacheFilename) {
     const tempFileName = `tmp-${process.pid}-${(ElectronDownloader.tmpFileCounter++).toString(16)}-${path.basename(cacheFilename)}`
-    debug('downloading', url, 'to', this.cache)
     const nuggetOpts = {
       target: tempFileName,
       dir: this.cache,
@@ -247,90 +255,74 @@ class ElectronDownloader {
       proxy: this.proxy,
       headers: this.headers
     }
-    nugget(url, nuggetOpts, (errors) => {
-      if (errors) {
+
+    debug('downloading', url, 'to', this.cache)
+    return pify(nugget)(url, nuggetOpts)
+      .catch(errors => {
         // nugget returns an array of errors but we only need 1st because we only have 1 url
-        return this.handleDownloadError(cb, errors[0])
-      }
-
-      this.moveFileToCache(tempFileName, cacheFilename, cb, onSuccess)
-    })
+        return this.handleDownloadError(errors[0])
+      }).then(() => this.moveFileToCache(tempFileName, cacheFilename))
   }
 
-  downloadIfNotCached (cb) {
-    if (!this.version) return cb(new Error('must specify version'))
+  downloadIfNotCached () {
+    if (!this.version) throw new Error('must specify version')
     debug('info', {cache: this.cache, filename: this.filename, url: this.url})
-    this.checkForCachedZip(cb)
+    return this.validateOptions()
+      .then(() => this.checkForCachedZip())
   }
 
-  downloadZip (cb) {
-    this.downloadFile(this.url, this.cachedZip, cb, this.checkIfZipNeedsVerifying.bind(this))
+  downloadZip () {
+    return this.downloadFile(this.url, this.cachedZip)
+      .then(() => this.checkIfZipNeedsVerifying())
   }
 
-  ensureCacheDir (cb) {
+  ensureCacheDir () {
     debug('creating cache dir')
-    this.createCacheDir((err, actualCache) => {
-      if (err) return cb(err)
-      this.opts.cache = actualCache // in case cache dir changed
-      this.downloadZip(cb)
-    })
+    return this.createCacheDir()
+      .then(actualCache => {
+        this.opts.cache = actualCache // in case cache dir changed
+        return this.downloadZip()
+      })
   }
 
-  handleDownloadError (cb, error) {
-    if (error.message.indexOf('404') === -1) return cb(error)
+  handleDownloadError (error) {
+    if (error.message.indexOf('404') === -1) throw error
     if (this.symbols) {
       error.message = `Failed to find Electron symbols v${this.version} for ${this.platform}-${this.arch} at ${this.url}`
     } else {
       error.message = `Failed to find Electron v${this.version} for ${this.platform}-${this.arch} at ${this.url}`
     }
 
-    return cb(error)
+    throw error
   }
 
-  moveFileToCache (filename, target, cb, onSuccess) {
+  moveFileToCache (filename, target) {
     const cache = this.cache
     debug('moving', filename, 'from', cache, 'to', target)
-    fs.rename(path.join(cache, filename), target, (err) => {
-      if (err) {
-        fs.unlink(cache, cleanupError => {
-          try {
-            if (cleanupError) {
-              console.error(`Error deleting cache file: ${cleanupError.message}`)
-            }
-          } finally {
-            cb(err)
-          }
-        })
-      } else {
-        onSuccess(cb)
-      }
-    })
+    return fs.rename(path.join(cache, filename), target)
+      .catch(err => this.cleanupLocation(cache, err))
   }
 
-  verifyChecksum (cb) {
+  verifyChecksum () {
     const options = {}
     if (semver.lt(this.version, '1.3.5')) {
       options.defaultTextEncoding = 'binary'
     }
     const checker = new sumchecker.ChecksumValidator('sha256', this.cachedChecksum, options)
-    checker.validate(this.cache, this.filename).then(() => {
-      cb(null, this.cachedZip)
-    }, (err) => {
-      fs.unlink(this.cachedZip, (fsErr) => {
-        if (fsErr) return cb(fsErr)
-        cb(err)
-      })
-    })
+    return checker.validate(this.cache, this.filename)
+      .catch(err => this.cleanupLocation(this.cachedZip, err))
+      .then(() => this.cachedZip)
+  }
+
+  cleanupLocation (location, error) {
+    return fs.unlink(location)
+      .then(() => { throw error })
   }
 }
 
 ElectronDownloader.tmpFileCounter = 0
 
 module.exports = function download (opts, cb) {
-  try {
-    const downloader = new ElectronDownloader(opts)
-    downloader.downloadIfNotCached(cb)
-  } catch (err) {
-    cb(err)
-  }
+  const downloader = new ElectronDownloader(opts)
+  return nodeify(downloader.downloadIfNotCached(), cb)
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "env-paths": "^1.0.0",
     "fs-extra": "^4.0.1",
     "minimist": "^1.2.0",
+    "nodeify": "^1.0.1",
     "nugget": "^2.0.1",
-    "path-exists": "^3.0.0",
+    "pify": "^3.0.0",
     "rc": "^1.2.1",
     "semver": "^5.4.1",
     "sumchecker": "^2.0.2"

--- a/readme.md
+++ b/readme.md
@@ -26,12 +26,11 @@ download({
   arch: 'ia32',
   platform: 'win32',
   cache: './zips'
-}, function (err, zipPath) {
+}).then(zipPath => {
   // zipPath will be the path of the zip that it downloaded.
-  // If the zip was already cached it will skip
-  // downloading and call the cb with the cached zip path.
-  // If it wasn't cached it will download the zip and save
-  // it in the cache path.
+  // If the zip was already cached it will skip downloading and resolve the
+  // Promise with the cached zip path. If it wasn't cached, it will download
+  // the zip and save it in the cache path.
 })
 ```
 


### PR DESCRIPTION
This is mostly code reorganization. It adds the `nodeify` module, which should be removed in the next major version bump, and `pify`, to promisify `nugget`. It also removes `path-exists` since the functionality is provided by `fs-extra`.

Fixes #70.