### PR TITLE
fix: process raw-passed arm architecture correctly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,7 @@ class ElectronDownloader {
   }
 
   get arch () {
-    return this.opts.arch || arch.host(this.quiet)
+    return (this.opts.arch && this.opts.arch !== 'arm') ? this.opts.arch : arch.host(this.quiet)
   }
 
   get cache () {


### PR DESCRIPTION
In the previous design of this change I took on too much, excuse me :)

This patch slightly improves ARM architecture processing. If you pass the `arm` string as the `arch` option's value (it can happen if you used, for example, `process.arch`), then `electron-download` will determine ARM version of your machine itself using it's `lib/arch.js`.

Bringing @malept and @MarshallOfSound in.