### PR TITLE
Update arch API/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,22 @@
 ### Simple: Downloading an Electron Binary ZIP
 
 ```js
-import { downloadElectron } from '@electron/download';
+import { download } from '@electron/download';
 
-const zipFilePath = await downloadElectron('4.0.4');
+const zipFilePath = await download('4.0.4');
 ```
 
 ### Advanced: Downloading a macOS Electron Symbol File
 
 
 ```js
-import { downloadElectron } from '@electron/download';
+import { downloadArtifact } from '@electron/download';
 
-const zipFilePath = await downloadElectron({
+const zipFilePath = await downloadArtifact({
   version: '4.0.4',
   platform: 'darwin',
-  assetName: 'electron',
-  assetSuffix: 'symbols',
+  artifactName: 'electron',
+  artifactSuffix: 'symbols',
   arch: 'x64',
 });
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ import { getArtifactFileName, getArtifactRemoteURL, FileNameUse } from './artifa
 import { ElectronArtifactDetails, ElectronDownloadRequestOptions } from './types';
 import { Cache } from './Cache';
 import { getDownloaderForSystem } from './downloader-resolver';
-import { withTempDirectory, normalizeVersion, getArch } from './utils';
+import { withTempDirectory, normalizeVersion, getHostArch } from './utils';
+
+export { getHostArch } from './utils';
 
 /**
  * Downloads a specific version of Electron and returns an absolute path to a
@@ -21,7 +23,7 @@ export function download(
     ...options,
     version,
     platform: process.platform,
-    arch: getArch(),
+    arch: getHostArch(),
     artifactName: 'electron',
   });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,9 @@ export function normalizeVersion(version: string) {
   return version;
 }
 
+/**
+ * Runs the `uname` command and returns the trimmed output.
+ */
 export function uname() {
   return childProcess
     .execSync('uname -m')
@@ -36,9 +39,19 @@ export function uname() {
     .trim();
 }
 
-export function getArch() {
-  const arch = process.arch;
+/**
+ * Generates an architecture name that would be used in an Electron or Node.js
+ * download file name, from the `process` module information.
+ */
+export function getHostArch() {
+  return getNodeArch(process.arch);
+}
 
+/**
+ * Generates an architecture name that would be used in an Electron or Node.js
+ * download file name.
+ */
+export function getNodeArch(arch: string) {
   if (arch === 'arm') {
     switch ((process.config.variables as any).arm_version) {
       case '6':

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -16,11 +16,7 @@ describe('utils', () => {
   describe('uname()', () => {
     if (process.platform !== 'win32') {
       it('should return the correct arch for your system', () => {
-        if (process.platform === 'darwin') {
-          expect(uname()).toEqual('x86_64');
-        } else {
-          expect(uname()).toEqual('x64');
-        }
+        expect(uname()).toEqual('x86_64');
       });
     }
   });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 
-import { normalizeVersion, uname, withTempDirectory, getArch } from '../src/utils';
+import { normalizeVersion, uname, withTempDirectory, getHostArch } from '../src/utils';
 
 describe('utils', () => {
   describe('normalizeVersion()', () => {
@@ -55,7 +55,7 @@ describe('utils', () => {
     });
   });
 
-  describe('getArch()', () => {
+  describe('getHostArch()', () => {
     let savedArch: string;
     let savedVariables: any;
 
@@ -75,14 +75,14 @@ describe('utils', () => {
       Object.defineProperty(process, 'arch', {
         value: 'x64',
       });
-      expect(getArch()).toEqual('x64');
+      expect(getHostArch()).toEqual('x64');
     });
 
     it('should return process.arch on ia32', () => {
       Object.defineProperty(process, 'arch', {
         value: 'ia32',
       });
-      expect(getArch()).toEqual('ia32');
+      expect(getHostArch()).toEqual('ia32');
     });
 
     it('should return process.arch on unknown arm', () => {
@@ -90,7 +90,7 @@ describe('utils', () => {
         value: 'arm',
       });
       process.config.variables = {} as any;
-      expect(getArch()).toEqual('arm');
+      expect(getHostArch()).toEqual('arm');
     });
 
     it('should return uname on arm 6', () => {
@@ -99,7 +99,7 @@ describe('utils', () => {
           value: 'arm',
         });
         process.config.variables = { arm_version: '6' } as any;
-        expect(getArch()).toEqual(uname());
+        expect(getHostArch()).toEqual(uname());
       }
     });
 
@@ -108,7 +108,7 @@ describe('utils', () => {
         value: 'arm',
       });
       process.config.variables = { arm_version: '7' } as any;
-      expect(getArch()).toEqual('armv7l');
+      expect(getHostArch()).toEqual('armv7l');
     });
   });
 });


### PR DESCRIPTION
* Fix `uname` test on Linux
* Sync API examples in the README with the actual API
* Rename/refactor the host arch API and re-export getHostArch so it can be used in places such as Electron Packager.